### PR TITLE
Google Fonts improvements

### DIFF
--- a/select/google-font-dropdown-custom-control.php
+++ b/select/google-font-dropdown-custom-control.php
@@ -1,97 +1,69 @@
 <?php
 
-if ( ! class_exists( 'WP_Customize_Control' ) )
-    return NULL;
-
 /**
- * A class to create a dropdown for all google fonts
+ * A class to create a dropdown for all google fonts.
+ * Forked from https://github.com/paulund/wordpress-theme-customizer-custom-controls/
  */
- class Google_Font_Dropdown_Custom_Control extends WP_Customize_Control
- {
-    private $fonts = false;
+ class Google_Font_Dropdown_Custom_Control extends WP_Customize_Control {
+	private $fonts = false;
 
-    public function __construct($manager, $id, $args = array(), $options = array())
-    {
-        $this->fonts = $this->get_fonts();
-        parent::__construct( $manager, $id, $args );
-    }
+	/**
+	 * Fire the constructor up :)
+	 *
+	 * @param [type] $manager [description]
+	 * @param [type] $id      [description]
+	 * @param array  $args    [description]
+	 * @param array  $options [description]
+	 */
+	public function __construct( $manager, $id, $args = array(), $options = array() ) {
+		$this->fonts = $this->get_fonts();
+		parent::__construct( $manager, $id, $args );
+	}
 
-    /**
-     * Render the content of the category dropdown
-     *
-     * @return HTML
-     */
-    public function render_content()
-    {
-        if(!empty($this->fonts))
-        {
-            ?>
-                <label>
-                    <span class="customize-category-select-control"><?php echo esc_html( $this->label ); ?></span>
-                    <select <?php $this->link(); ?>>
-                        <?php
-                            foreach ( $this->fonts as $k => $v )
-                            {
-                                printf('<option value="%s" %s>%s</option>', $k, selected($this->value(), $k, false), $v->family);
-                            }
-                        ?>
-                    </select>
-                </label>
-            <?php
-        }
-    }
+	/**
+	 * Render the content of the category dropdown
+	 */
+	public function render_content() {
+		if ( ! empty( $this->fonts ) ) {
+			?>
+				<label>
+					<span class="customize-category-select-control"><?php echo esc_html( $this->label ); ?></span>
+					<select <?php $this->link(); ?>>
+						<?php
+							foreach ( $this->fonts as $k => $v ) {
+								printf( '<option value="%s" %s>%s</option>', esc_attr( $k ), selected( $this->value(), esc_html( $k ), false ), $v->family );
+							}
+						?>
+					</select>
+				</label>
+			<?php
+		}
+	}
 
-    /**
-     * Get the google fonts from the API or in the cache
-     *
-     * @param  integer $amount
-     *
-     * @return String
-     */
-    public function get_fonts( $amount = 30 )
-    {
-        $selectDirectory = get_stylesheet_directory().'/wordpress-theme-customizer-custom-controls/select/';
-        $selectDirectoryInc = get_stylesheet_directory().'/inc/wordpress-theme-customizer-custom-controls/select/';
+	/**
+	 * Get the google fonts from the API or in the cache.
+	 *
+	 * @return string
+	 */
+	public function get_fonts() {
 
-        $finalselectDirectory = '';
+		// If the Google Fonts API is set, then pull data from Google, otherwise default to stored font data
+		if ( defined( 'GOOGLE_FONTS_API_KEY' ) ) {
 
-        if(is_dir($selectDirectory))
-        {
-            $finalselectDirectory = $selectDirectory;
-        }
+			// We cache the data from Google
+			if ( false === ( $fonts = get_transient( $transient_key ) ) ) {
+				$google_api = 'https://www.googleapis.com/webfonts/v1/webfonts?sort=popularity&key=' . GOOGLE_FONTS_API_KEY;
+				$fonts = wp_remote_get( $google_api, array( 'sslverify'   => false ) );
+				set_transient( $transient_key, $fonts, HOUR_IN_SECONDS );
+			}
 
-        if(is_dir($selectDirectoryInc))
-        {
-            $finalselectDirectory = $selectDirectoryInc;
-        }
+		} else {
+			$fonts['body'] = file_get_contents( 'google-web-fonts-request.txt' );
+		}
 
-        $fontFile = $finalselectDirectory . '/cache/google-web-fonts.txt';
+		$content = json_decode( $fonts['body'] );
 
-        //Total time the file will be cached in seconds, set to a week
-        $cachetime = 86400 * 7;
+		return $content->items;
+	}
 
-        if(file_exists($fontFile) && $cachetime < filemtime($fontFile))
-        {
-            $content = json_decode(file_get_contents($fontFile));
-        } else {
-
-            $googleApi = 'https://www.googleapis.com/webfonts/v1/webfonts?sort=popularity&key={API_KEY}';
-
-            $fontContent = wp_remote_get( $googleApi, array('sslverify'   => false) );
-
-            $fp = fopen($fontFile, 'w');
-            fwrite($fp, $fontContent['body']);
-            fclose($fp);
-
-            $content = json_decode($fontContent['body']);
-        }
-
-        if($amount == 'all')
-        {
-            return $content->items;
-        } else {
-            return array_slice($content->items, 0, $amount);
-        }
-    }
- }
-?>
+}

--- a/select/google-web-fonts-request.txt
+++ b/select/google-web-fonts-request.txt
@@ -1,0 +1,13605 @@
+{
+ "kind": "webfonts#webfontList",
+ "items": [
+  {
+   "kind": "webfonts#webfont",
+   "family": "Open Sans",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic",
+    "800",
+    "800italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v13",
+   "lastModified": "2015-05-18",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTS3USBnSvpkopQaUR-2r7iU.ttf",
+    "300italic": "http://fonts.gstatic.com/s/opensans/v13/PRmiXeptR36kaC0GEAetxi9-WlPSxbfiI49GsXo3q0g.ttf",
+    "regular": "http://fonts.gstatic.com/s/opensans/v13/IgZJs4-7SA1XX_edsoXWog.ttf",
+    "italic": "http://fonts.gstatic.com/s/opensans/v13/O4NhV7_qs9r9seTo7fnsVKCWcynf_cDxXwCLxiixG1c.ttf",
+    "600": "http://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSi3USBnSvpkopQaUR-2r7iU.ttf",
+    "600italic": "http://fonts.gstatic.com/s/opensans/v13/PRmiXeptR36kaC0GEAetxpZ7xm-Bj30Bj2KNdXDzSZg.ttf",
+    "700": "http://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzC3USBnSvpkopQaUR-2r7iU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/opensans/v13/PRmiXeptR36kaC0GEAetxne1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "800": "http://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hi3USBnSvpkopQaUR-2r7iU.ttf",
+    "800italic": "http://fonts.gstatic.com/s/opensans/v13/PRmiXeptR36kaC0GEAetxg89PwPrYLaRFJ-HNCU9NbA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Roboto",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "100italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v15",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/roboto/v15/7MygqTe2zs9YkP0adA9QQQ.ttf",
+    "100italic": "http://fonts.gstatic.com/s/roboto/v15/T1xnudodhcgwXCmZQ490TPesZW2xOQ-xsNqO47m55DA.ttf",
+    "300": "http://fonts.gstatic.com/s/roboto/v15/dtpHsbgPEm2lVWciJZ0P-A.ttf",
+    "300italic": "http://fonts.gstatic.com/s/roboto/v15/iE8HhaRzdhPxC93dOdA056CWcynf_cDxXwCLxiixG1c.ttf",
+    "regular": "http://fonts.gstatic.com/s/roboto/v15/W5F8_SL0XFawnjxHGsZjJA.ttf",
+    "italic": "http://fonts.gstatic.com/s/roboto/v15/hcKoSgxdnKlbH5dlTwKbow.ttf",
+    "500": "http://fonts.gstatic.com/s/roboto/v15/Uxzkqj-MIMWle-XP2pDNAA.ttf",
+    "500italic": "http://fonts.gstatic.com/s/roboto/v15/daIfzbEw-lbjMyv4rMUUTqCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/roboto/v15/bdHGHleUa-ndQCOrdpfxfw.ttf",
+    "700italic": "http://fonts.gstatic.com/s/roboto/v15/owYYXKukxFDFjr0ZO8NXh6CWcynf_cDxXwCLxiixG1c.ttf",
+    "900": "http://fonts.gstatic.com/s/roboto/v15/H1vB34nOKWXqzKotq25pcg.ttf",
+    "900italic": "http://fonts.gstatic.com/s/roboto/v15/b9PWBSMHrT2zM5FgUdtu0aCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lato",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "100italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v11",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/lato/v11/Upp-ka9rLQmHYCsFgwL-eg.ttf",
+    "100italic": "http://fonts.gstatic.com/s/lato/v11/zLegi10uS_9-fnUDISl0KA.ttf",
+    "300": "http://fonts.gstatic.com/s/lato/v11/Ja02qOppOVq9jeRjWekbHg.ttf",
+    "300italic": "http://fonts.gstatic.com/s/lato/v11/dVebFcn7EV7wAKwgYestUg.ttf",
+    "regular": "http://fonts.gstatic.com/s/lato/v11/h7rISIcQapZBpei-sXwIwg.ttf",
+    "italic": "http://fonts.gstatic.com/s/lato/v11/P_dJOFJylV3A870UIOtr0w.ttf",
+    "700": "http://fonts.gstatic.com/s/lato/v11/iX_QxBBZLhNj5JHlTzHQzg.ttf",
+    "700italic": "http://fonts.gstatic.com/s/lato/v11/WFcZakHrrCKeUJxHA4T_gw.ttf",
+    "900": "http://fonts.gstatic.com/s/lato/v11/8TPEV6NbYWZlNsXjbYVv7w.ttf",
+    "900italic": "http://fonts.gstatic.com/s/lato/v11/draWperrI7n2xi35Cl08fA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oswald",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/oswald/v10/y3tZpCdiRD4oNRRYFcAR5Q.ttf",
+    "regular": "http://fonts.gstatic.com/s/oswald/v10/uLEd2g2vJglLPfsBF91DCg.ttf",
+    "700": "http://fonts.gstatic.com/s/oswald/v10/7wj8ldV_5Ti37rHa0m1DDw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Slabo 27px",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/slabo27px/v3/gC0o8B9eU21EafNkXlRAfPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Roboto Condensed",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v13",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/robotocondensed/v13/b9QBgL0iMZfDSpmcXcE8nJRhFVcex_hajThhFkHyhYk.ttf",
+    "300italic": "http://fonts.gstatic.com/s/robotocondensed/v13/mg0cGfGRUERshzBlvqxeAPYa9bgCHecWXGgisnodcS0.ttf",
+    "regular": "http://fonts.gstatic.com/s/robotocondensed/v13/Zd2E9abXLFGSr9G3YK2MsKDbm6fPDOZJsR8PmdG62gY.ttf",
+    "italic": "http://fonts.gstatic.com/s/robotocondensed/v13/BP5K8ZAJv9qEbmuFp8RpJY_eiqgTfYGaH0bJiUDZ5GA.ttf",
+    "700": "http://fonts.gstatic.com/s/robotocondensed/v13/b9QBgL0iMZfDSpmcXcE8nPOYkGiSOYDq_T7HbIOV1hA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/robotocondensed/v13/mg0cGfGRUERshzBlvqxeAE2zk2RGRC3SlyyLLQfjS_8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lora",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lora/v9/aXJ7KVIGcejEy1abawZazg.ttf",
+    "italic": "http://fonts.gstatic.com/s/lora/v9/AN2EZaj2tFRpyveuNn9BOg.ttf",
+    "700": "http://fonts.gstatic.com/s/lora/v9/enKND5SfzQKkggBA_VnT1A.ttf",
+    "700italic": "http://fonts.gstatic.com/s/lora/v9/ivs9j3kYU65pR9QD9YFdzQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Source Sans Pro",
+   "category": "sans-serif",
+   "variants": [
+    "200",
+    "200italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGKXvKVW_haheDNrHjziJZVk.ttf",
+    "200italic": "http://fonts.gstatic.com/s/sourcesanspro/v9/fpTVHK8qsXbIeTHTrnQH6OptKU7UIBg2hLM7eMTU8bI.ttf",
+    "300": "http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGFP7R5lD_au4SZC6Ks_vyWs.ttf",
+    "300italic": "http://fonts.gstatic.com/s/sourcesanspro/v9/fpTVHK8qsXbIeTHTrnQH6DUpNKoQAsDux-Todp8f29w.ttf",
+    "regular": "http://fonts.gstatic.com/s/sourcesanspro/v9/ODelI1aHBYDBqgeIAH2zlNRl0pGnog23EMYRrBmUzJQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/sourcesanspro/v9/M2Jd71oPJhLKp0zdtTvoMwRX4TIfMQQEXLu74GftruE.ttf",
+    "600": "http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGOiMeWyi5E_-XkTgB5psiDg.ttf",
+    "600italic": "http://fonts.gstatic.com/s/sourcesanspro/v9/fpTVHK8qsXbIeTHTrnQH6Pp6lGoTTgjlW0sC4r900Co.ttf",
+    "700": "http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGPgXsetDviZcdR5OzC1KPcw.ttf",
+    "700italic": "http://fonts.gstatic.com/s/sourcesanspro/v9/fpTVHK8qsXbIeTHTrnQH6LVT4locI09aamSzFGQlDMY.ttf",
+    "900": "http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGBA_awHl7mXRjE_LQVochcU.ttf",
+    "900italic": "http://fonts.gstatic.com/s/sourcesanspro/v9/fpTVHK8qsXbIeTHTrnQH6A0NcF6HPGWR298uWIdxWv0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Montserrat",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/montserrat/v6/Kqy6-utIpx_30Xzecmeo8_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/montserrat/v6/IQHow_FEYlDC4Gzy_m8fcgJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "PT Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ptsans/v8/UFoEz2uiuMypUGZL1NKoeg.ttf",
+    "italic": "http://fonts.gstatic.com/s/ptsans/v8/yls9EYWOd496wiu7qzfgNg.ttf",
+    "700": "http://fonts.gstatic.com/s/ptsans/v8/F51BEgHuR0tYHxF0bD4vwvesZW2xOQ-xsNqO47m55DA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/ptsans/v8/lILlYDvubYemzYzN7GbLkC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Open Sans Condensed",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/opensanscondensed/v10/gk5FxslNkTTHtojXrkp-xEMwSSh38KQVJx4ABtsZTnA.ttf",
+    "300italic": "http://fonts.gstatic.com/s/opensanscondensed/v10/jIXlqT1WKafUSwj6s9AzV4_LkTZ_uhAwfmGJ084hlvM.ttf",
+    "700": "http://fonts.gstatic.com/s/opensanscondensed/v10/gk5FxslNkTTHtojXrkp-xBEM87DM3yorPOrvA-vB930.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Raleway",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/raleway/v9/UDfD6oxBaBnmFJwQ7XAFNw.ttf",
+    "200": "http://fonts.gstatic.com/s/raleway/v9/LAQwev4hdCtYkOYX4Oc7nPesZW2xOQ-xsNqO47m55DA.ttf",
+    "300": "http://fonts.gstatic.com/s/raleway/v9/2VvSZU2kb4DZwFfRM4fLQPesZW2xOQ-xsNqO47m55DA.ttf",
+    "regular": "http://fonts.gstatic.com/s/raleway/v9/_dCzxpXzIS3sL-gdJWAP8A.ttf",
+    "500": "http://fonts.gstatic.com/s/raleway/v9/348gn6PEmbLDWlHbbV15d_esZW2xOQ-xsNqO47m55DA.ttf",
+    "600": "http://fonts.gstatic.com/s/raleway/v9/M7no6oPkwKYJkedjB1wqEvesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/raleway/v9/VGEV9-DrblisWOWLbK-1XPesZW2xOQ-xsNqO47m55DA.ttf",
+    "800": "http://fonts.gstatic.com/s/raleway/v9/mMh0JrsYMXcLO69jgJwpUvesZW2xOQ-xsNqO47m55DA.ttf",
+    "900": "http://fonts.gstatic.com/s/raleway/v9/ajQQGcDBLcyLpaUfD76UuPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Droid Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/droidsans/v6/rS9BT6-asrfjpkcV3DXf__esZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/droidsans/v6/EFpQQyG9GqCrobXxL-KRMQJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ubuntu",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-26",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/ubuntu/v8/7-wH0j2QCTHKgp7vLh9-sQ.ttf",
+    "300italic": "http://fonts.gstatic.com/s/ubuntu/v8/j-TYDdXcC_eQzhhp386SjaCWcynf_cDxXwCLxiixG1c.ttf",
+    "regular": "http://fonts.gstatic.com/s/ubuntu/v8/lhhB5ZCwEkBRbHMSnYuKyA.ttf",
+    "italic": "http://fonts.gstatic.com/s/ubuntu/v8/b9hP8wd30SygxZjGGk4DCQ.ttf",
+    "500": "http://fonts.gstatic.com/s/ubuntu/v8/bMbHEMwSUmkzcK2x_74QbA.ttf",
+    "500italic": "http://fonts.gstatic.com/s/ubuntu/v8/NWdMogIO7U6AtEM4dDdf_aCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/ubuntu/v8/B7BtHjNYwAp3HgLNagENOQ.ttf",
+    "700italic": "http://fonts.gstatic.com/s/ubuntu/v8/pqisLQoeO9YTDCNnlQ9bf6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Roboto Slab",
+   "category": "serif",
+   "variants": [
+    "100",
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/robotoslab/v6/MEz38VLIFL-t46JUtkIEgIAWxXGWZ3yJw6KhWS7MxOk.ttf",
+    "300": "http://fonts.gstatic.com/s/robotoslab/v6/dazS1PrQQuCxC3iOAJFEJS9-WlPSxbfiI49GsXo3q0g.ttf",
+    "regular": "http://fonts.gstatic.com/s/robotoslab/v6/3__ulTNA7unv0UtplybPiqCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/robotoslab/v6/dazS1PrQQuCxC3iOAJFEJXe1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Droid Serif",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/droidserif/v6/DgAtPy6rIVa2Zx3Xh9KaNaCWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/droidserif/v6/cj2hUnSRBhwmSPr9kS5890eOrDcLawS7-ssYqLr2Xp4.ttf",
+    "700": "http://fonts.gstatic.com/s/droidserif/v6/QQt14e8dY39u-eYBZmppwXe1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/droidserif/v6/c92rD_x0V1LslSFt3-QEps_zJjSACmk0BRPxQqhnNLU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Merriweather",
+   "category": "serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/merriweather/v8/ZvcMqxEwPfh2qDWBPxn6nqcQoVhARpoaILP7amxE_8g.ttf",
+    "300italic": "http://fonts.gstatic.com/s/merriweather/v8/EYh7Vl4ywhowqULgRdYwICna0FLWfcB-J_SAYmcAXaI.ttf",
+    "regular": "http://fonts.gstatic.com/s/merriweather/v8/RFda8w1V0eDZheqfcyQ4EC3USBnSvpkopQaUR-2r7iU.ttf",
+    "italic": "http://fonts.gstatic.com/s/merriweather/v8/So5lHxHT37p2SS4-t60SlPMZXuCXbOrAvx5R0IT5Oyo.ttf",
+    "700": "http://fonts.gstatic.com/s/merriweather/v8/ZvcMqxEwPfh2qDWBPxn6nkD2ttfZwueP-QU272T9-k4.ttf",
+    "700italic": "http://fonts.gstatic.com/s/merriweather/v8/EYh7Vl4ywhowqULgRdYwIPAs9-1nE9qOqhChW0m4nDE.ttf",
+    "900": "http://fonts.gstatic.com/s/merriweather/v8/ZvcMqxEwPfh2qDWBPxn6nqObDOjC3UL77puoeHsE3fw.ttf",
+    "900italic": "http://fonts.gstatic.com/s/merriweather/v8/EYh7Vl4ywhowqULgRdYwIBd0_s6jQr9r5s5OZYvtzBY.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Arimo",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "hebrew",
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-28",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/arimo/v9/Gpeo80g-5ji2CcyXWnzh7g.ttf",
+    "italic": "http://fonts.gstatic.com/s/arimo/v9/_OdGbnX2-qQ96C4OjhyuPw.ttf",
+    "700": "http://fonts.gstatic.com/s/arimo/v9/ZItXugREyvV9LnbY_gxAmw.ttf",
+    "700italic": "http://fonts.gstatic.com/s/arimo/v9/__nOLWqmeXdhfr0g7GaFePesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "PT Sans Narrow",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ptsansnarrow/v7/UyYrYy3ltEffJV9QueSi4ZTvAuddT2xDMbdz0mdLyZY.ttf",
+    "700": "http://fonts.gstatic.com/s/ptsansnarrow/v7/Q_pTky3Sc3ubRibGToTAYsLtdzs3iyjn_YuT226ZsLU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Noto Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/notosans/v6/0Ue9FiUJwVhi4NGfHJS5uA.ttf",
+    "italic": "http://fonts.gstatic.com/s/notosans/v6/dLcNKMgJ1H5RVoZFraDz0qCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/notosans/v6/PIbvSEyHEdL91QLOQRnZ1y3USBnSvpkopQaUR-2r7iU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/notosans/v6/9Z3uUWMRR7crzm1TjRicDne1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Poiret One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/poiretone/v4/dWcYed048E5gHGDIt8i1CPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "PT Serif",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ptserif/v8/sAo427rn3-QL9sWCbMZXhA.ttf",
+    "italic": "http://fonts.gstatic.com/s/ptserif/v8/9khWhKzhpkH0OkNnBKS3n_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/ptserif/v8/kyZw18tqQ5if-_wpmxxOeKCWcynf_cDxXwCLxiixG1c.ttf",
+    "700italic": "http://fonts.gstatic.com/s/ptserif/v8/Foydq9xJp--nfYIx2TBz9QJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Titillium Web",
+   "category": "sans-serif",
+   "variants": [
+    "200",
+    "200italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/titilliumweb/v4/anMUvcNT0H1YN4FII8wprzOdCrLccoxq42eaxM802O0.ttf",
+    "200italic": "http://fonts.gstatic.com/s/titilliumweb/v4/RZunN20OBmkvrU7sA4GPPj4N98U-66ThNJvtgddRfBE.ttf",
+    "300": "http://fonts.gstatic.com/s/titilliumweb/v4/anMUvcNT0H1YN4FII8wpr9ZAkYT8DuUZELiKLwMGWAo.ttf",
+    "300italic": "http://fonts.gstatic.com/s/titilliumweb/v4/RZunN20OBmkvrU7sA4GPPrfzCkqg7ORZlRf2cc4mXu8.ttf",
+    "regular": "http://fonts.gstatic.com/s/titilliumweb/v4/7XUFZ5tgS-tD6QamInJTcTyagQBwYgYywpS70xNq8SQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/titilliumweb/v4/r9OmwyQxrgzUAhaLET_KO-ixohbIP6lHkU-1Mgq95cY.ttf",
+    "600": "http://fonts.gstatic.com/s/titilliumweb/v4/anMUvcNT0H1YN4FII8wpr28K9dEd5Ue-HTQrlA7E2xQ.ttf",
+    "600italic": "http://fonts.gstatic.com/s/titilliumweb/v4/RZunN20OBmkvrU7sA4GPPgOhzTSndyK8UWja2yJjKLc.ttf",
+    "700": "http://fonts.gstatic.com/s/titilliumweb/v4/anMUvcNT0H1YN4FII8wpr2-6tpSbB9YhmWtmd1_gi_U.ttf",
+    "700italic": "http://fonts.gstatic.com/s/titilliumweb/v4/RZunN20OBmkvrU7sA4GPPio3LEw-4MM8Ao2j9wPOfpw.ttf",
+    "900": "http://fonts.gstatic.com/s/titilliumweb/v4/anMUvcNT0H1YN4FII8wpr7L0GmZLri-m-nfoo0Vul4Y.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Indie Flower",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/indieflower/v8/10JVD_humAd5zP2yrFqw6i3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bitter",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bitter/v7/w_BNdJvVZDRmqy5aSfB2kQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/bitter/v7/TC0FZEVzXQIGgzmRfKPZbA.ttf",
+    "700": "http://fonts.gstatic.com/s/bitter/v7/4dUtr_4BvHuoRU35suyOAg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alegreya Sans",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "100italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "700",
+    "700italic",
+    "800",
+    "800italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/alegreyasans/v3/TKyx_-JJ6MdpQruNk-t-PJFGFO4uyVFMfB6LZsii7kI.ttf",
+    "100italic": "http://fonts.gstatic.com/s/alegreyasans/v3/gRkSP2lBpqoMTVxg7DmVn2cDnjsrnI9_xJ-5gnBaHsE.ttf",
+    "300": "http://fonts.gstatic.com/s/alegreyasans/v3/11EDm-lum6tskJMBbdy9acB1LjARzAvdqa1uQC32v70.ttf",
+    "300italic": "http://fonts.gstatic.com/s/alegreyasans/v3/WfiXipsmjqRqsDBQ1bA9CnfqlVoxTUFFx1C8tBqmbcg.ttf",
+    "regular": "http://fonts.gstatic.com/s/alegreyasans/v3/KYNzioYhDai7mTMnx_gDgn8f0n03UdmQgF_CLvNR2vg.ttf",
+    "italic": "http://fonts.gstatic.com/s/alegreyasans/v3/TKyx_-JJ6MdpQruNk-t-PD4G9C9ttb0Oz5Cvf0qOitE.ttf",
+    "500": "http://fonts.gstatic.com/s/alegreyasans/v3/11EDm-lum6tskJMBbdy9aQqQmZ7VjhwksfpNVG0pqGc.ttf",
+    "500italic": "http://fonts.gstatic.com/s/alegreyasans/v3/WfiXipsmjqRqsDBQ1bA9Cs7DCVO6wo6i5LKIyZDzK40.ttf",
+    "700": "http://fonts.gstatic.com/s/alegreyasans/v3/11EDm-lum6tskJMBbdy9aVCbmAUID8LN-q3pJpOk3Ys.ttf",
+    "700italic": "http://fonts.gstatic.com/s/alegreyasans/v3/WfiXipsmjqRqsDBQ1bA9CpF66r9C4AnxxlBlGd7xY4g.ttf",
+    "800": "http://fonts.gstatic.com/s/alegreyasans/v3/11EDm-lum6tskJMBbdy9acxnD5BewVtRRHHljCwR2bM.ttf",
+    "800italic": "http://fonts.gstatic.com/s/alegreyasans/v3/WfiXipsmjqRqsDBQ1bA9CicOAJ_9MkLPbDmrtXDPbIU.ttf",
+    "900": "http://fonts.gstatic.com/s/alegreyasans/v3/11EDm-lum6tskJMBbdy9aW42xlVP-j5dagE7-AU2zwg.ttf",
+    "900italic": "http://fonts.gstatic.com/s/alegreyasans/v3/WfiXipsmjqRqsDBQ1bA9ChRaDUI9aE8-k7PrIG2iiuo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fjalla One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fjallaone/v4/3b7vWCfOZsU53vMa8LWsf_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dosis",
+   "category": "sans-serif",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/dosis/v4/ztftab0r6hcd7AeurUGrSQ.ttf",
+    "300": "http://fonts.gstatic.com/s/dosis/v4/awIB6L0h5mb0plIKorXmuA.ttf",
+    "regular": "http://fonts.gstatic.com/s/dosis/v4/rJRlixu-w0JZ1MyhJpao_Q.ttf",
+    "500": "http://fonts.gstatic.com/s/dosis/v4/ruEXDOFMxDPGnjCBKRqdAQ.ttf",
+    "600": "http://fonts.gstatic.com/s/dosis/v4/KNAswRNwm3tfONddYyidxg.ttf",
+    "700": "http://fonts.gstatic.com/s/dosis/v4/AEEAj0ONidK8NQQMBBlSig.ttf",
+    "800": "http://fonts.gstatic.com/s/dosis/v4/nlrKd8E69vvUU39XGsvR7Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lobster",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v15",
+   "lastModified": "2015-07-21",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lobster/v15/9LpJGtNuM1D8FAZ2BkJH2Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Yanone Kaffeesatz",
+   "category": "sans-serif",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/yanonekaffeesatz/v7/We_iSDqttE3etzfdfhuPRbq92v6XxU4pSv06GI0NsGc.ttf",
+    "300": "http://fonts.gstatic.com/s/yanonekaffeesatz/v7/We_iSDqttE3etzfdfhuPRZlIwXPiNoNT_wxzJ2t3mTE.ttf",
+    "regular": "http://fonts.gstatic.com/s/yanonekaffeesatz/v7/YDAoLskQQ5MOAgvHUQCcLdXn3cHbFGWU4T2HrSN6JF4.ttf",
+    "700": "http://fonts.gstatic.com/s/yanonekaffeesatz/v7/We_iSDqttE3etzfdfhuPRf2R4S6PlKaGXWPfWpHpcl0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Playfair Display",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/playfairdisplay/v10/2NBgzUtEeyB-Xtpr9bm1CV6uyC_qD11hrFQ6EGgTJWI.ttf",
+    "italic": "http://fonts.gstatic.com/s/playfairdisplay/v10/9MkijrV-dEJ0-_NWV7E6NzMsbnvDNEBX25F5HWk9AhI.ttf",
+    "700": "http://fonts.gstatic.com/s/playfairdisplay/v10/UC3ZEjagJi85gF9qFaBgICsv6SrURqJprbhH_C1Mw8w.ttf",
+    "700italic": "http://fonts.gstatic.com/s/playfairdisplay/v10/n7G4PqJvFP2Kubl0VBLDECsYW3XoOVcYyYdp9NzzS9E.ttf",
+    "900": "http://fonts.gstatic.com/s/playfairdisplay/v10/UC3ZEjagJi85gF9qFaBgIKqwMe2wjvZrAR44M0BJZ48.ttf",
+    "900italic": "http://fonts.gstatic.com/s/playfairdisplay/v10/n7G4PqJvFP2Kubl0VBLDEC0JfJ4xmm7j1kL6D7mPxrA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Candal",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/candal/v6/x44dDW28zK7GR1gGDBmj9g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oxygen",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-08-26",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/oxygen/v5/lZ31r0bR1Bzt_DfGZu1S8A.ttf",
+    "regular": "http://fonts.gstatic.com/s/oxygen/v5/uhoyAE7XlQL22abzQieHjw.ttf",
+    "700": "http://fonts.gstatic.com/s/oxygen/v5/yLqkmDwuNtt5pSqsJmhyrg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Hind",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/hind/v5/qa346Adgv9kPDXoD1my4kA.ttf",
+    "regular": "http://fonts.gstatic.com/s/hind/v5/mktFHh5Z5P9YjGKSslSUtA.ttf",
+    "500": "http://fonts.gstatic.com/s/hind/v5/2cs8RCVcYtiv4iNDH1UsQQ.ttf",
+    "600": "http://fonts.gstatic.com/s/hind/v5/TUKUmFMXSoxloBP1ni08oA.ttf",
+    "700": "http://fonts.gstatic.com/s/hind/v5/cXJJavLdUbCfjxlsA6DqTw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cabin",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cabin/v7/XeuAFYo2xAPHxZGBbQtHhA.ttf",
+    "italic": "http://fonts.gstatic.com/s/cabin/v7/0tJ9k3DI5xC4GBgs1E_Jxw.ttf",
+    "500": "http://fonts.gstatic.com/s/cabin/v7/HgsCQ-k3_Z_uQ86aFolNBg.ttf",
+    "500italic": "http://fonts.gstatic.com/s/cabin/v7/50sjhrGE0njyO-7mGDhGP_esZW2xOQ-xsNqO47m55DA.ttf",
+    "600": "http://fonts.gstatic.com/s/cabin/v7/eUDAvKhBtmTCkeVBsFk34A.ttf",
+    "600italic": "http://fonts.gstatic.com/s/cabin/v7/sFQpQDBd3G2om0Nl5dD2CvesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/cabin/v7/4EKhProuY1hq_WCAomq9Dg.ttf",
+    "700italic": "http://fonts.gstatic.com/s/cabin/v7/K83QKi8MOKLEqj6bgZ7LrfesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Arvo",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-08-26",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/arvo/v9/vvWPwz-PlZEwjOOIKqoZzA.ttf",
+    "italic": "http://fonts.gstatic.com/s/arvo/v9/id5a4BCjbenl5Gkqonw_Rw.ttf",
+    "700": "http://fonts.gstatic.com/s/arvo/v9/OB3FDST7U38u3OjPK_vvRQ.ttf",
+    "700italic": "http://fonts.gstatic.com/s/arvo/v9/Hvl2MuWoXLaCy2v6MD4Yvw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Passion One",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/passionone/v6/1UIK1tg3bKJ4J3o35M4heqCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/passionone/v6/feOcYDy2R-f3Ysy72PYJ2ne1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "900": "http://fonts.gstatic.com/s/passionone/v6/feOcYDy2R-f3Ysy72PYJ2ienaqEuufTBk9XMKnKmgDA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Muli",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/muli/v7/VJw4F3ZHRAZ7Hmg3nQu5YQ.ttf",
+    "300italic": "http://fonts.gstatic.com/s/muli/v7/s-NKMCru8HiyjEt0ZDoBoA.ttf",
+    "regular": "http://fonts.gstatic.com/s/muli/v7/KJiP6KznxbALQgfJcDdPAw.ttf",
+    "italic": "http://fonts.gstatic.com/s/muli/v7/Cg0K_IWANs9xkNoxV7H1_w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Noto Serif",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/notoserif/v4/zW6mc7bC1CWw8dH0yxY8JfesZW2xOQ-xsNqO47m55DA.ttf",
+    "italic": "http://fonts.gstatic.com/s/notoserif/v4/HQXBIwLHsOJCNEQeX9kNzy3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/notoserif/v4/lJAvZoKA5NttpPc9yc6lPQJKKGfqHaYFsRG-T3ceEVo.ttf",
+    "700italic": "http://fonts.gstatic.com/s/notoserif/v4/Wreg0Be4tcFGM2t6VWytvED2ttfZwueP-QU272T9-k4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Abel",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/abel/v6/RpUKfqNxoyNe_ka23bzQ2A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Inconsolata",
+   "category": "monospace",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v11",
+   "lastModified": "2015-05-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/inconsolata/v11/7bMKuoy6Nh0ft0SHnIGMuaCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/inconsolata/v11/AIed271kqQlcIRSOnQH0yXe1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nunito",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/nunito/v7/zXQvrWBJqUooM7Xv98MrQw.ttf",
+    "regular": "http://fonts.gstatic.com/s/nunito/v7/ySZTeT3IuzJj0GK6uGpbBg.ttf",
+    "700": "http://fonts.gstatic.com/s/nunito/v7/aEdlqgMuYbpe4U3TnqOQMA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Vollkorn",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/vollkorn/v6/IiexqYAeh8uII223thYx3w.ttf",
+    "italic": "http://fonts.gstatic.com/s/vollkorn/v6/UuIzosgR1ovBhJFdwVp3fvesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/vollkorn/v6/gOwQjJVGXlDOONC12hVoBqCWcynf_cDxXwCLxiixG1c.ttf",
+    "700italic": "http://fonts.gstatic.com/s/vollkorn/v6/KNiAlx6phRqXCwnZZG51JAJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bree Serif",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/breeserif/v5/5h9crBVIrvZqgf34FHcnEfesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Orbitron",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "500",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/orbitron/v7/DY8swouAZjR3RaUPRf0HDQ.ttf",
+    "500": "http://fonts.gstatic.com/s/orbitron/v7/p-y_ffzMdo5JN_7ia0vYEqCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/orbitron/v7/PS9_6SLkY1Y6OgPO3APr6qCWcynf_cDxXwCLxiixG1c.ttf",
+    "900": "http://fonts.gstatic.com/s/orbitron/v7/2I3-8i9hT294TE_pyjy9SaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Pacifico",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pacifico/v7/GIrpeRY1r5CzbfL8r182lw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Archivo Narrow",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/archivonarrow/v5/DsLzC9scoPnrGiwYYMQXppTvAuddT2xDMbdz0mdLyZY.ttf",
+    "italic": "http://fonts.gstatic.com/s/archivonarrow/v5/vqsrtPCpTU3tJlKfuXP5zUpmlyBQEFfdE6dERLXdQGQ.ttf",
+    "700": "http://fonts.gstatic.com/s/archivonarrow/v5/M__Wu4PAmHf4YZvQM8tWsMLtdzs3iyjn_YuT226ZsLU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/archivonarrow/v5/wG6O733y5zHl4EKCOh8rSTg5KB8MNJ4uPAETq9naQO8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Signika",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/signika/v6/0wDPonOzsYeEo-1KO78w4fesZW2xOQ-xsNqO47m55DA.ttf",
+    "regular": "http://fonts.gstatic.com/s/signika/v6/WvDswbww0oAtvBg2l1L-9w.ttf",
+    "600": "http://fonts.gstatic.com/s/signika/v6/lQMOF6NUN2ooR7WvB7tADvesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/signika/v6/lEcnfPBICWJPv5BbVNnFJPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Francois One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/francoisone/v9/bYbkq2nU2TSx4SwFbz5sCC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ubuntu Condensed",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-26",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ubuntucondensed/v7/DBCt-NXN57MTAFjitYxdrKDbm6fPDOZJsR8PmdG62gY.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Josefin Sans",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "100italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/josefinsans/v9/q9w3H4aeBxj0hZ8Osfi3d8SVQ0giZ-l_NELu3lgGyYw.ttf",
+    "100italic": "http://fonts.gstatic.com/s/josefinsans/v9/s7-P1gqRNRNn-YWdOYnAOXXcj1rQwlNLIS625o-SrL0.ttf",
+    "300": "http://fonts.gstatic.com/s/josefinsans/v9/C6HYlRF50SGJq1XyXj04z6cQoVhARpoaILP7amxE_8g.ttf",
+    "300italic": "http://fonts.gstatic.com/s/josefinsans/v9/ppse0J9fKSaoxCIIJb33Gyna0FLWfcB-J_SAYmcAXaI.ttf",
+    "regular": "http://fonts.gstatic.com/s/josefinsans/v9/xgzbb53t8j-Mo-vYa23n5i3USBnSvpkopQaUR-2r7iU.ttf",
+    "italic": "http://fonts.gstatic.com/s/josefinsans/v9/q9w3H4aeBxj0hZ8Osfi3d_MZXuCXbOrAvx5R0IT5Oyo.ttf",
+    "600": "http://fonts.gstatic.com/s/josefinsans/v9/C6HYlRF50SGJq1XyXj04z2v8CylhIUtwUiYO7Z2wXbE.ttf",
+    "600italic": "http://fonts.gstatic.com/s/josefinsans/v9/ppse0J9fKSaoxCIIJb33G4R-5-urNOGAobhAyctHvW8.ttf",
+    "700": "http://fonts.gstatic.com/s/josefinsans/v9/C6HYlRF50SGJq1XyXj04z0D2ttfZwueP-QU272T9-k4.ttf",
+    "700italic": "http://fonts.gstatic.com/s/josefinsans/v9/ppse0J9fKSaoxCIIJb33G_As9-1nE9qOqhChW0m4nDE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Play",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/play/v6/GWvfObW8LhtsOX333MCpBg.ttf",
+    "700": "http://fonts.gstatic.com/s/play/v6/crPhg6I0alLI-MpB3vW-zw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Shadows Into Light",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/shadowsintolight/v6/clhLqOv7MXn459PTh0gXYAW_5bEze-iLRNvGrRpJsfM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cuprum",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cuprum/v7/JgXs0F_UiaEdAS74msmFNg.ttf",
+    "italic": "http://fonts.gstatic.com/s/cuprum/v7/cLEz0KV6OxInnktSzpk58g.ttf",
+    "700": "http://fonts.gstatic.com/s/cuprum/v7/6tl3_FkDeXSD72oEHuJh4w.ttf",
+    "700italic": "http://fonts.gstatic.com/s/cuprum/v7/bnkXaBfoYvaJ75axRPSwVKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Libre Baskerville",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/librebaskerville/v4/pR0sBQVcY0JZc_ciXjFsKyyZRYCSvpCzQKuMWnP5NDY.ttf",
+    "italic": "http://fonts.gstatic.com/s/librebaskerville/v4/QHIOz1iKF3bIEzRdDFaf5QnhapNS5Oi8FPrBRDLbsW4.ttf",
+    "700": "http://fonts.gstatic.com/s/librebaskerville/v4/kH7K4InNTm7mmOXXjrA5v-xuswJKUVpBRfYFpz0W3Iw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Asap",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/asap/v4/2lf-1MDR8tsTpEtvJmr2hA.ttf",
+    "italic": "http://fonts.gstatic.com/s/asap/v4/mwxNHf8QS8gNWCAMwkJNIg.ttf",
+    "700": "http://fonts.gstatic.com/s/asap/v4/o5RUA7SsJ80M8oDFBnrDbg.ttf",
+    "700italic": "http://fonts.gstatic.com/s/asap/v4/_rZz9y2oXc09jT5T6BexLQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Maven Pro",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "500",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mavenpro/v7/sqPJIFG4gqsjl-0q_46Gbw.ttf",
+    "500": "http://fonts.gstatic.com/s/mavenpro/v7/SQVfzoJBbj9t3aVcmbspRi3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/mavenpro/v7/uDssvmXgp7Nj3i336k_dSi3USBnSvpkopQaUR-2r7iU.ttf",
+    "900": "http://fonts.gstatic.com/s/mavenpro/v7/-91TwiFzqeL1F7Kh91APwS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sigmar One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sigmarone/v6/oh_5NxD5JBZksdo2EntKefesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Merriweather Sans",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "800",
+    "800italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/merriweathersans/v5/6LmGj5dOJopQKEkt88Gowan5N8K-_DP0e9e_v51obXQ.ttf",
+    "300italic": "http://fonts.gstatic.com/s/merriweathersans/v5/nAqt4hiqwq3tzCecpgPmVdytE4nGXk2hYD5nJ740tBw.ttf",
+    "regular": "http://fonts.gstatic.com/s/merriweathersans/v5/AKu1CjQ4qnV8MUltkAX3sOAj_ty82iuwwDTNEYXGiyQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/merriweathersans/v5/3Mz4hOHzs2npRMG3B1ascZ32VBCoA_HLsn85tSWZmdo.ttf",
+    "700": "http://fonts.gstatic.com/s/merriweathersans/v5/6LmGj5dOJopQKEkt88GowbqxG25nQNOioCZSK4sU-CA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/merriweathersans/v5/nAqt4hiqwq3tzCecpgPmVbuqAJxizi8Dk_SK5et7kMg.ttf",
+    "800": "http://fonts.gstatic.com/s/merriweathersans/v5/6LmGj5dOJopQKEkt88GowYufzO2zUYSj5LqoJ3UGkco.ttf",
+    "800italic": "http://fonts.gstatic.com/s/merriweathersans/v5/nAqt4hiqwq3tzCecpgPmVdDmPrYMy3aZO4LmnZsxTQw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Exo 2",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "100italic",
+    "200",
+    "200italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic",
+    "800",
+    "800italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/exo2/v3/oVOtQy53isv97g4UhBUDqg.ttf",
+    "100italic": "http://fonts.gstatic.com/s/exo2/v3/LNYVgsJcaCxoKFHmd4AZcg.ttf",
+    "200": "http://fonts.gstatic.com/s/exo2/v3/qa-Ci2pBwJdCxciE1ErifQ.ttf",
+    "200italic": "http://fonts.gstatic.com/s/exo2/v3/DCrVxDVvS69n50O-5erZVvesZW2xOQ-xsNqO47m55DA.ttf",
+    "300": "http://fonts.gstatic.com/s/exo2/v3/nLUBdz_lHHoVIPor05Byhw.ttf",
+    "300italic": "http://fonts.gstatic.com/s/exo2/v3/iSy9VTeUTiqiurQg2ywtu_esZW2xOQ-xsNqO47m55DA.ttf",
+    "regular": "http://fonts.gstatic.com/s/exo2/v3/Pf_kZuIH5c5WKVkQUaeSWQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/exo2/v3/xxA5ZscX9sTU6U0lZJUlYA.ttf",
+    "500": "http://fonts.gstatic.com/s/exo2/v3/oM0rzUuPqVJpW-VEIpuW5w.ttf",
+    "500italic": "http://fonts.gstatic.com/s/exo2/v3/amzRVCB-gipwdihZZ2LtT_esZW2xOQ-xsNqO47m55DA.ttf",
+    "600": "http://fonts.gstatic.com/s/exo2/v3/YnSn3HsyvyI1feGSdRMYqA.ttf",
+    "600italic": "http://fonts.gstatic.com/s/exo2/v3/Vmo58BiptGwfVFb0teU5gPesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/exo2/v3/2DiK4XkdTckfTk6we73-bQ.ttf",
+    "700italic": "http://fonts.gstatic.com/s/exo2/v3/Sdo-zW-4_--pDkTg6bYrY_esZW2xOQ-xsNqO47m55DA.ttf",
+    "800": "http://fonts.gstatic.com/s/exo2/v3/IVYl_7dJruOg8zKRpC8Hrw.ttf",
+    "800italic": "http://fonts.gstatic.com/s/exo2/v3/p0TA6KeOz1o4rySEbvUxI_esZW2xOQ-xsNqO47m55DA.ttf",
+    "900": "http://fonts.gstatic.com/s/exo2/v3/e8csG8Wnu87AF6uCndkFRQ.ttf",
+    "900italic": "http://fonts.gstatic.com/s/exo2/v3/KPhsGCoT2-7Uj6pMlRscH_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Quicksand",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/quicksand/v5/qhfoJiLu10kFjChCCTvGlC3USBnSvpkopQaUR-2r7iU.ttf",
+    "regular": "http://fonts.gstatic.com/s/quicksand/v5/Ngv3fIJjKB7sD-bTUGIFCA.ttf",
+    "700": "http://fonts.gstatic.com/s/quicksand/v5/32nyIRHyCu6iqEka_hbKsi3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rokkitt",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-08-26",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rokkitt/v9/GMA7Z_ToF8uSvpZAgnp_VQ.ttf",
+    "700": "http://fonts.gstatic.com/s/rokkitt/v9/gxlo-sr3rPmvgSixYog_ofesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Crimson Text",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/crimsontext/v6/3IFMwfRa07i-auYR-B-zNS3USBnSvpkopQaUR-2r7iU.ttf",
+    "italic": "http://fonts.gstatic.com/s/crimsontext/v6/a5QZnvmn5amyNI-t2BMkWPMZXuCXbOrAvx5R0IT5Oyo.ttf",
+    "600": "http://fonts.gstatic.com/s/crimsontext/v6/rEy5tGc5HdXy56Xvd4f3I2v8CylhIUtwUiYO7Z2wXbE.ttf",
+    "600italic": "http://fonts.gstatic.com/s/crimsontext/v6/4j4TR-EfnvCt43InYpUNDIR-5-urNOGAobhAyctHvW8.ttf",
+    "700": "http://fonts.gstatic.com/s/crimsontext/v6/rEy5tGc5HdXy56Xvd4f3I0D2ttfZwueP-QU272T9-k4.ttf",
+    "700italic": "http://fonts.gstatic.com/s/crimsontext/v6/4j4TR-EfnvCt43InYpUNDPAs9-1nE9qOqhChW0m4nDE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Anton",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/anton/v7/XIbCenm-W0IRHWYIh7CGUQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "PT Sans Caption",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ptsanscaption/v9/OXYTDOzBcXU8MTNBvBHeSW8by34Z3mUMtM-o4y-SHCY.ttf",
+    "700": "http://fonts.gstatic.com/s/ptsanscaption/v9/Q-gJrFokeE7JydPpxASt25tc0eyfI4QDEsobEEpk_hA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alegreya",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alegreya/v7/62J3atXd6bvMU4qO_ca-eA.ttf",
+    "italic": "http://fonts.gstatic.com/s/alegreya/v7/cbshnQGxwmlHBjUil7DaIfesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/alegreya/v7/5oZtdI5-wQwgAFrd9erCsaCWcynf_cDxXwCLxiixG1c.ttf",
+    "700italic": "http://fonts.gstatic.com/s/alegreya/v7/IWi8e5bpnqhMRsZKTcTUWgJKKGfqHaYFsRG-T3ceEVo.ttf",
+    "900": "http://fonts.gstatic.com/s/alegreya/v7/oQeMxX-vxGImzDgX6nxA7KCWcynf_cDxXwCLxiixG1c.ttf",
+    "900italic": "http://fonts.gstatic.com/s/alegreya/v7/-L71QLH_XqgYWaI1GbOVhp0EAVxt0G0biEntp43Qt6E.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Varela Round",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/varelaround/v6/APH4jr0uSos5wiut5cpjri3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Karla",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/karla/v5/78UgGRwJFkhqaoFimqoKpQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/karla/v5/51UBKly9RQOnOkj95ZwEFw.ttf",
+    "700": "http://fonts.gstatic.com/s/karla/v5/JS501sZLxZ4zraLQdncOUA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/karla/v5/3YDyi09gQjCRh-5-SVhTTvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fira Sans",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/firasans/v5/VTBnrK42EiOBncVyQXZ7jy3USBnSvpkopQaUR-2r7iU.ttf",
+    "300italic": "http://fonts.gstatic.com/s/firasans/v5/6s0YCA9oCTF6hM60YM-qTS9-WlPSxbfiI49GsXo3q0g.ttf",
+    "regular": "http://fonts.gstatic.com/s/firasans/v5/nsT0isDy56OkSX99sFQbXw.ttf",
+    "italic": "http://fonts.gstatic.com/s/firasans/v5/cPT_2ddmoxsUuMtQqa8zGqCWcynf_cDxXwCLxiixG1c.ttf",
+    "500": "http://fonts.gstatic.com/s/firasans/v5/zM2u8V3CuPVwAAXFQcDi4C3USBnSvpkopQaUR-2r7iU.ttf",
+    "500italic": "http://fonts.gstatic.com/s/firasans/v5/6s0YCA9oCTF6hM60YM-qTcCNfqCYlB_eIx7H1TVXe60.ttf",
+    "700": "http://fonts.gstatic.com/s/firasans/v5/DugPdSljmOTocZOR2CItOi3USBnSvpkopQaUR-2r7iU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/firasans/v5/6s0YCA9oCTF6hM60YM-qTXe1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Exo",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "100italic",
+    "200",
+    "200italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic",
+    "800",
+    "800italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/exo/v4/RI7A9uwjRmPbVp0n8e-Jvg.ttf",
+    "100italic": "http://fonts.gstatic.com/s/exo/v4/qtGyZZlWb2EEvby3ZPosxw.ttf",
+    "200": "http://fonts.gstatic.com/s/exo/v4/F8OfC_swrRRxpFt-tlXZQg.ttf",
+    "200italic": "http://fonts.gstatic.com/s/exo/v4/fr4HBfXHYiIngW2_bhlgRw.ttf",
+    "300": "http://fonts.gstatic.com/s/exo/v4/SBrN7TKUqgGUvfxqHqsnNw.ttf",
+    "300italic": "http://fonts.gstatic.com/s/exo/v4/3gmiLjBegIfcDLISjTGA1g.ttf",
+    "regular": "http://fonts.gstatic.com/s/exo/v4/eUEzTFueNXRVhbt4PEB8kQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/exo/v4/cfgolWisMSURhpQeVHl_NA.ttf",
+    "500": "http://fonts.gstatic.com/s/exo/v4/jCg6DmGGXt_OVyp5ofQHPw.ttf",
+    "500italic": "http://fonts.gstatic.com/s/exo/v4/lo5eTdCNJZQVN08p8RnzAQ.ttf",
+    "600": "http://fonts.gstatic.com/s/exo/v4/q_SG5kXUmOcIvFpgtdZnlw.ttf",
+    "600italic": "http://fonts.gstatic.com/s/exo/v4/0cExa8K_pxS2lTuMr68XUA.ttf",
+    "700": "http://fonts.gstatic.com/s/exo/v4/3_jwsL4v9uHjl5Q37G57mw.ttf",
+    "700italic": "http://fonts.gstatic.com/s/exo/v4/0me55yJIxd5vyQ9bF7SsiA.ttf",
+    "800": "http://fonts.gstatic.com/s/exo/v4/yLPuxBuV0lzqibRJyooOJg.ttf",
+    "800italic": "http://fonts.gstatic.com/s/exo/v4/n3LejeKVj_8gtZq5fIgNYw.ttf",
+    "900": "http://fonts.gstatic.com/s/exo/v4/97d0nd6Yv4-SA_X92xAuZA.ttf",
+    "900italic": "http://fonts.gstatic.com/s/exo/v4/JHTkQVhzyLtkY13Ye95TJQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dancing Script",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dancingscript/v6/DK0eTGXiZjN6yA8zAEyM2RnpV0hQCek3EmWnCPrvGRM.ttf",
+    "700": "http://fonts.gstatic.com/s/dancingscript/v6/KGBfwabt0ZRLA5W1ywjowb_dAmXiKjTPGCuO6G2MbfA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Monda",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/monda/v4/qFMHZ9zvR6B_gnoIgosPrw.ttf",
+    "700": "http://fonts.gstatic.com/s/monda/v4/EVOzZUyc_j1w2GuTgTAW1g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gudea",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gudea/v4/S-4QqBlkMPiiA3jNeCR5yw.ttf",
+    "italic": "http://fonts.gstatic.com/s/gudea/v4/7mNgsGw_vfS-uUgRVXNDSw.ttf",
+    "700": "http://fonts.gstatic.com/s/gudea/v4/lsip4aiWhJ9bx172Y9FN_w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Questrial",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/questrial/v6/MoHHaw_WwNs_hd9ob1zTVw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "EB Garamond",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ebgaramond/v7/CDR0kuiFK7I1OZ2hSdR7G6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Pathway Gothic One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pathwaygothicone/v4/Lqv9ztoTUV8Q0FmQZzPqaA6A6xIYD7vYcYDop1i-K-c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Crete Round",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/creteround/v5/B8EwN421qqOCCT8vOH4wJ6CWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/creteround/v5/5xAt7XK2vkUdjhGtt98unUeOrDcLawS7-ssYqLr2Xp4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Abril Fatface",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/abrilfatface/v8/X1g_KwGeBV3ajZIXQ9VnDojjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Patua One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/patuaone/v6/njZwotTYjswR4qdhsW-kJw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Josefin Slab",
+   "category": "serif",
+   "variants": [
+    "100",
+    "100italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/josefinslab/v6/etsUjZYO8lTLU85lDhZwUsSVQ0giZ-l_NELu3lgGyYw.ttf",
+    "100italic": "http://fonts.gstatic.com/s/josefinslab/v6/8BjDChqLgBF3RJKfwHIYh3Xcj1rQwlNLIS625o-SrL0.ttf",
+    "300": "http://fonts.gstatic.com/s/josefinslab/v6/NbE6ykYuM2IyEwxQxOIi2KcQoVhARpoaILP7amxE_8g.ttf",
+    "300italic": "http://fonts.gstatic.com/s/josefinslab/v6/af9sBoKGPbGO0r21xJulyyna0FLWfcB-J_SAYmcAXaI.ttf",
+    "regular": "http://fonts.gstatic.com/s/josefinslab/v6/46aYWdgz-1oFX11flmyEfS3USBnSvpkopQaUR-2r7iU.ttf",
+    "italic": "http://fonts.gstatic.com/s/josefinslab/v6/etsUjZYO8lTLU85lDhZwUvMZXuCXbOrAvx5R0IT5Oyo.ttf",
+    "600": "http://fonts.gstatic.com/s/josefinslab/v6/NbE6ykYuM2IyEwxQxOIi2Gv8CylhIUtwUiYO7Z2wXbE.ttf",
+    "600italic": "http://fonts.gstatic.com/s/josefinslab/v6/af9sBoKGPbGO0r21xJuly4R-5-urNOGAobhAyctHvW8.ttf",
+    "700": "http://fonts.gstatic.com/s/josefinslab/v6/NbE6ykYuM2IyEwxQxOIi2ED2ttfZwueP-QU272T9-k4.ttf",
+    "700italic": "http://fonts.gstatic.com/s/josefinslab/v6/af9sBoKGPbGO0r21xJuly_As9-1nE9qOqhChW0m4nDE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Istok Web",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v10",
+   "lastModified": "2015-06-11",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/istokweb/v10/RYLSjEXQ0nNtLLc4n7--dQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/istokweb/v10/kvcT2SlTjmGbC3YlZxmrl6CWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/istokweb/v10/2koEo4AKFSvK4B52O_Mwai3USBnSvpkopQaUR-2r7iU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/istokweb/v10/ycQ3g52ELrh3o_HYCNNUw3e1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "BenchNine",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/benchnine/v4/ah9xtUy9wLQ3qnWa2p-piS3USBnSvpkopQaUR-2r7iU.ttf",
+    "regular": "http://fonts.gstatic.com/s/benchnine/v4/h3OAlYqU3aOeNkuXgH2Q2w.ttf",
+    "700": "http://fonts.gstatic.com/s/benchnine/v4/qZpi6ZVZg3L2RL_xoBLxWS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Architects Daughter",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/architectsdaughter/v6/RXTgOOQ9AAtaVOHxx0IUBMCy0EhZjHzu-y0e6uLf4Fg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Source Code Pro",
+   "category": "monospace",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/sourcecodepro/v6/leqv3v-yTsJNC7nFznSMqaXvKVW_haheDNrHjziJZVk.ttf",
+    "300": "http://fonts.gstatic.com/s/sourcecodepro/v6/leqv3v-yTsJNC7nFznSMqVP7R5lD_au4SZC6Ks_vyWs.ttf",
+    "regular": "http://fonts.gstatic.com/s/sourcecodepro/v6/mrl8jkM18OlOQN8JLgasD9Rl0pGnog23EMYRrBmUzJQ.ttf",
+    "500": "http://fonts.gstatic.com/s/sourcecodepro/v6/leqv3v-yTsJNC7nFznSMqX63uKwMO11Of4rJWV582wg.ttf",
+    "600": "http://fonts.gstatic.com/s/sourcecodepro/v6/leqv3v-yTsJNC7nFznSMqeiMeWyi5E_-XkTgB5psiDg.ttf",
+    "700": "http://fonts.gstatic.com/s/sourcecodepro/v6/leqv3v-yTsJNC7nFznSMqfgXsetDviZcdR5OzC1KPcw.ttf",
+    "900": "http://fonts.gstatic.com/s/sourcecodepro/v6/leqv3v-yTsJNC7nFznSMqRA_awHl7mXRjE_LQVochcU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Covered By Your Grace",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/coveredbyyourgrace/v6/6ozZp4BPlrbDRWPe3EBGA6CVUMdvnk-GcAiZQrX9Gek.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gloria Hallelujah",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gloriahallelujah/v8/CA1k7SlXcY5kvI81M_R28Q3RdPdyebSUyJECJouPsvA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bangers",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bangers/v8/WAffdge5w99Xif-DLeqmcA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Amatic SC",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-07-22",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/amaticsc/v7/MldbRWLFytvqxU1y81xSVg.ttf",
+    "700": "http://fonts.gstatic.com/s/amaticsc/v7/IDnkRTPGcrSVo50UyYNK7y3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ropa Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ropasans/v5/Gba7ZzVBuhg6nX_AoSwlkQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/ropasans/v5/V1zbhZQscNrh63dy5Jk2nqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "News Cycle",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v13",
+   "lastModified": "2015-04-16",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/newscycle/v13/xyMAr8VfiUzIOvS1abHJO_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/newscycle/v13/G28Ny31cr5orMqEQy6ljtwJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Armata",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/armata/v6/1H8FwGgIRrbYtxSfXhOHlQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Pontano Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pontanosans/v4/gTHiwyxi6S7iiHpqAoiE3C3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chewy",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chewy/v7/hcDN5cvQdIu6Bx4mg_TSyw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Righteous",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/righteous/v5/0nRRWM_gCGCt2S-BCfN8WQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Noticia Text",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/noticiatext/v6/wdyV6x3eKpdeUPQ7BJ5uUC3USBnSvpkopQaUR-2r7iU.ttf",
+    "italic": "http://fonts.gstatic.com/s/noticiatext/v6/dAuxVpkYE_Q_IwIm6elsKPMZXuCXbOrAvx5R0IT5Oyo.ttf",
+    "700": "http://fonts.gstatic.com/s/noticiatext/v6/pEko-RqEtp45bE2P80AAKUD2ttfZwueP-QU272T9-k4.ttf",
+    "700italic": "http://fonts.gstatic.com/s/noticiatext/v6/-rQ7V8ARjf28_b7kRa0JuvAs9-1nE9qOqhChW0m4nDE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Quattrocento Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/quattrocentosans/v8/efd6FGWWGX5Z3ztwLBrG9eAj_ty82iuwwDTNEYXGiyQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/quattrocentosans/v8/8PXYbvM__bjl0rBnKiByg532VBCoA_HLsn85tSWZmdo.ttf",
+    "700": "http://fonts.gstatic.com/s/quattrocentosans/v8/tXSgPxDl7Lk8Zr_5qX8FIbqxG25nQNOioCZSK4sU-CA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/quattrocentosans/v8/8N1PdXpbG6RtFvTjl-5E7buqAJxizi8Dk_SK5et7kMg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kaushan Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kaushanscript/v4/qx1LSqts-NtiKcLw4N03IBnpV0hQCek3EmWnCPrvGRM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Old Standard TT",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/oldstandardtt/v7/n6RTCDcIPWSE8UNBa4k-DLcB5jyhm1VsHs65c3QNDr0.ttf",
+    "italic": "http://fonts.gstatic.com/s/oldstandardtt/v7/QQT_AUSp4AV4dpJfIN7U5PWrQzeMtsHf8QsWQ2cZg3c.ttf",
+    "700": "http://fonts.gstatic.com/s/oldstandardtt/v7/5Ywdce7XEbTSbxs__4X1_HJqbZqK7TdZ58X80Q_Lw8Y.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cabin Condensed",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cabincondensed/v7/B0txb0blf2N29WdYPJjMSiQPsWWoiv__AzYJ9Zzn9II.ttf",
+    "500": "http://fonts.gstatic.com/s/cabincondensed/v7/Ez4zJbsGr2BgXcNUWBVgEARL_-ABKXdjsJSPT0lc2Bk.ttf",
+    "600": "http://fonts.gstatic.com/s/cabincondensed/v7/Ez4zJbsGr2BgXcNUWBVgELS5sSASxc8z4EQTQj7DCAI.ttf",
+    "700": "http://fonts.gstatic.com/s/cabincondensed/v7/Ez4zJbsGr2BgXcNUWBVgEMAWgzcA047xWLixhLCofl8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "ABeeZee",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/abeezee/v4/mE5BOuZKGln_Ex0uYKpIaw.ttf",
+    "italic": "http://fonts.gstatic.com/s/abeezee/v4/kpplLynmYgP0YtlJA3atRw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sanchez",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sanchez/v4/BEL8ao-E2LJ5eHPLB2UAiw.ttf",
+    "italic": "http://fonts.gstatic.com/s/sanchez/v4/iSrhkWLexUZzDeNxNEHtzA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Hammersmith One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/hammersmithone/v7/FWNn6ITYqL6or7ZTmBxRhjjVlsJB_M_Q_LtZxsoxvlw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lobster Two",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lobstertwo/v7/xb9aY4w9ceh8JRzobID1naCWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/lobstertwo/v7/Ul_16MSbfayQv1I4QhLEoEeOrDcLawS7-ssYqLr2Xp4.ttf",
+    "700": "http://fonts.gstatic.com/s/lobstertwo/v7/bmdxOflBqMqjEC0-kGsIiHe1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/lobstertwo/v7/LEkN2_no_6kFvRfiBZ8xpM_zJjSACmk0BRPxQqhnNLU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tinos",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "hebrew",
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-28",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tinos/v9/EqpUbkVmutfwZ0PjpoGwCg.ttf",
+    "italic": "http://fonts.gstatic.com/s/tinos/v9/slfyzlasCr9vTsaP4lUh9A.ttf",
+    "700": "http://fonts.gstatic.com/s/tinos/v9/vHXfhX8jZuQruowfon93yQ.ttf",
+    "700italic": "http://fonts.gstatic.com/s/tinos/v9/M6kfzvDMM0CdxdraoFpG6vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cantarell",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cantarell/v6/p5ydP_uWQ5lsFzcP_XVMEw.ttf",
+    "italic": "http://fonts.gstatic.com/s/cantarell/v6/DTCLtOSqP-7dgM-V_xKUjqCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/cantarell/v6/Yir4ZDsCn4g1kWopdg-ehC3USBnSvpkopQaUR-2r7iU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/cantarell/v6/weehrwMeZBXb0QyrWnRwFXe1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Courgette",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/courgette/v4/2YO0EYtyE9HUPLZprahpZA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fredoka One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fredokaone/v4/QKfwXi-z-KtJAlnO2ethYqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ruda",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ruda/v7/jPEIPB7DM2DNK_uBGv2HGw.ttf",
+    "700": "http://fonts.gstatic.com/s/ruda/v7/JABOu1SYOHcGXVejUq4w6g.ttf",
+    "900": "http://fonts.gstatic.com/s/ruda/v7/Uzusv-enCjoIrznlJJaBRw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Comfortaa",
+   "category": "display",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/comfortaa/v7/r_tUZNl0G8xCoOmp_JkSCi3USBnSvpkopQaUR-2r7iU.ttf",
+    "regular": "http://fonts.gstatic.com/s/comfortaa/v7/lZx6C1VViPgSOhCBUP7hXA.ttf",
+    "700": "http://fonts.gstatic.com/s/comfortaa/v7/fND5XPYKrF2tQDwwfWZJIy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Archivo Black",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/archivoblack/v4/WoAoVT7K3k7hHfxKbvB6B51XQG8isOYYJhPIYAyrESQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Coming Soon",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/comingsoon/v6/Yz2z3IAe2HSQAOWsSG8COKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sintony",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sintony/v4/IDhCijoIMev2L6Lg5QsduQ.ttf",
+    "700": "http://fonts.gstatic.com/s/sintony/v4/zVXQB1wqJn6PE4dWXoYpvPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cinzel",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cinzel/v4/GF7dy_Nc-a6EaHYSyGd-EA.ttf",
+    "700": "http://fonts.gstatic.com/s/cinzel/v4/nYcFQ6_3pf_6YDrOFjBR8Q.ttf",
+    "900": "http://fonts.gstatic.com/s/cinzel/v4/FTBj72ozM2cEOSxiVsRb3A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Philosopher",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/philosopher/v7/oZLTrB9jmJsyV0u_T0TKEaCWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/philosopher/v7/_9Hnc_gz9k7Qq6uKaeHKmUeOrDcLawS7-ssYqLr2Xp4.ttf",
+    "700": "http://fonts.gstatic.com/s/philosopher/v7/napvkewXG9Gqby5vwGHICHe1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/philosopher/v7/PuKlryTcvTj7-qZWfLCFIM_zJjSACmk0BRPxQqhnNLU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Satisfy",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/satisfy/v6/PRlyepkd-JCGHiN8e9WV2w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alfa Slab One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alfaslabone/v5/Qx6FPcitRwTC_k88tLPc-Yjjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kreon",
+   "category": "serif",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/kreon/v9/HKtJRiq5C2zbq5N1IX32sA.ttf",
+    "regular": "http://fonts.gstatic.com/s/kreon/v9/zA_IZt0u0S3cvHJu-n1oEg.ttf",
+    "700": "http://fonts.gstatic.com/s/kreon/v9/jh0dSmaPodjxISiblIUTkw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lateef",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin",
+    "arabic"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lateef/v10/PAsKCgi1qc7XPwvzo_I-DQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rock Salt",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rocksalt/v6/Zy7JF9h9WbhD9V3SFMQ1UQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Source Serif Pro",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sourceserifpro/v4/CeUM4np2c42DV49nanp55YGL0S0YDpKs5GpLtZIQ0m4.ttf",
+    "600": "http://fonts.gstatic.com/s/sourceserifpro/v4/yd5lDMt8Sva2PE17yiLarGi4cQnvCGV11m1KlXh97aQ.ttf",
+    "700": "http://fonts.gstatic.com/s/sourceserifpro/v4/yd5lDMt8Sva2PE17yiLarEkpYHRvxGNSCrR82n_RDNk.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Didact Gothic",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/didactgothic/v7/v8_72sD3DYMKyM0dn3LtWotBLojGU5Qdl8-5NL4v70w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Russo One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/russoone/v5/zfwxZ--UhUc7FVfgT21PRQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fauna One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/faunaone/v4/8kL-wpAPofcAMELI_5NRnQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Playball",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/playball/v6/3hOFiQm_EUzycTpcN9uz4w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Economica",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/economica/v4/G4rJRujzZbq9Nxngu9l3hg.ttf",
+    "italic": "http://fonts.gstatic.com/s/economica/v4/p5O9AVeUqx_n35xQRinNYaCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/economica/v4/UK4l2VEpwjv3gdcwbwXE9C3USBnSvpkopQaUR-2r7iU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/economica/v4/ac5dlUsedQ03RqGOeay-3Xe1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Carrois Gothic",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/carroisgothic/v4/GCgb7bssGpwp7V5ynxmWy2x3d0cwUleGuRTmCYfCUaM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cardo",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "greek-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cardo/v8/jbkF2_R0FKUEZTq5dwSknQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/cardo/v8/pcv4Np9tUkq0YREYUcEEJQ.ttf",
+    "700": "http://fonts.gstatic.com/s/cardo/v8/lQN30weILimrKvp8rZhF1w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Permanent Marker",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/permanentmarker/v5/9vYsg5VgPHKK8SXYbf3sMol14xj5tdg9OHF8w4E7StQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Handlee",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/handlee/v5/6OfkXkyC0E5NZN80ED8u3A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tangerine",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tangerine/v7/DTPeM3IROhnkz7aYG2a9sA.ttf",
+    "700": "http://fonts.gstatic.com/s/tangerine/v7/UkFsr-RwJB_d2l9fIWsx3i3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nobile",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/nobile/v7/lC_lPi1ddtN38iXTCRh6ow.ttf",
+    "italic": "http://fonts.gstatic.com/s/nobile/v7/vGmrpKzWQQSrb-PR6FWBIA.ttf",
+    "700": "http://fonts.gstatic.com/s/nobile/v7/9p6M-Yrg_r_QPmSD1skrOg.ttf",
+    "700italic": "http://fonts.gstatic.com/s/nobile/v7/oQ1eYPaXV638N03KvsNvyKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Varela",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/varela/v7/ON7qs0cKUUixhhDFXlZUjw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bevan",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bevan/v7/Rtg3zDsCeQiaJ_Qno22OJA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Paytone One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/paytoneone/v8/3WCxC7JAJjQHQVoIE0ZwvqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Antic Slab",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/anticslab/v4/PSbJCTKkAS7skPdkd7AKEvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chivo",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chivo/v7/L88PEuzS9eRfHRZhAPhZyw.ttf",
+    "italic": "http://fonts.gstatic.com/s/chivo/v7/Oe3-Q-a2kBzPnhHck_baMg.ttf",
+    "900": "http://fonts.gstatic.com/s/chivo/v7/JAdkiWd46QCW4vOsj3dzTA.ttf",
+    "900italic": "http://fonts.gstatic.com/s/chivo/v7/LoszYnE86q2wJEOjCigBQ_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Quattrocento",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/quattrocento/v7/WZDISdyil4HsmirlOdBRFC3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/quattrocento/v7/Uvi-cRwyvqFpl9j3oT2mqkD2ttfZwueP-QU272T9-k4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Shadows Into Light Two",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/shadowsintolighttwo/v4/gDxHeefcXIo-lOuZFCn2xVQrZk-Pga5KeEE_oZjkQjQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Special Elite",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/specialelite/v6/9-wW4zu3WNoD5Fjka35Jm4jjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Amaranth",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/amaranth/v6/7VcBog22JBHsHXHdnnycTA.ttf",
+    "italic": "http://fonts.gstatic.com/s/amaranth/v6/UrJlRY9LcVERJSvggsdBqPesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/amaranth/v6/j5OFHqadfxyLnQRxFeox6qCWcynf_cDxXwCLxiixG1c.ttf",
+    "700italic": "http://fonts.gstatic.com/s/amaranth/v6/BHyuYFj9nqLFNvOvGh0xTwJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Signika Negative",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/signikanegative/v5/q5TOjIw4CenPw6C-TW06FjYFXpUPtCmIEFDvjUnLLaI.ttf",
+    "regular": "http://fonts.gstatic.com/s/signikanegative/v5/Z-Q1hzbY8uAo3TpTyPFMXVM1lnCWMnren5_v6047e5A.ttf",
+    "600": "http://fonts.gstatic.com/s/signikanegative/v5/q5TOjIw4CenPw6C-TW06FrKLaDJM01OezSVA2R_O3qI.ttf",
+    "700": "http://fonts.gstatic.com/s/signikanegative/v5/q5TOjIw4CenPw6C-TW06FpYzPxtVvobH1w3hEppR8WI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Advent Pro",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/adventpro/v4/87-JOpSUecTG50PBYK4ysi3USBnSvpkopQaUR-2r7iU.ttf",
+    "200": "http://fonts.gstatic.com/s/adventpro/v4/URTSSjIp0Wr-GrjxFdFWnGeudeTO44zf-ht3k-KNzwg.ttf",
+    "300": "http://fonts.gstatic.com/s/adventpro/v4/sJaBfJYSFgoB80OL1_66m0eOrDcLawS7-ssYqLr2Xp4.ttf",
+    "regular": "http://fonts.gstatic.com/s/adventpro/v4/1NxMBeKVcNNH2H46AUR3wfesZW2xOQ-xsNqO47m55DA.ttf",
+    "500": "http://fonts.gstatic.com/s/adventpro/v4/7kBth2-rT8tP40RmMMXMLJp-63r6doWhTEbsfBIRJ7A.ttf",
+    "600": "http://fonts.gstatic.com/s/adventpro/v4/3Jo-2maCzv2QLzQBzaKHV_pTEJqju4Hz1txDWij77d4.ttf",
+    "700": "http://fonts.gstatic.com/s/adventpro/v4/M4I6QiICt-ey_wZTpR2gKwJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cookie",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cookie/v7/HxeUC62y_YdDbiFlze357A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Droid Sans Mono",
+   "category": "monospace",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/droidsansmono/v7/ns-m2xQYezAtqh7ai59hJcwD6PD0c3_abh9zHKQtbGU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Scada",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/scada/v4/iZNC3ZEYwe3je6H-28d5Ug.ttf",
+    "italic": "http://fonts.gstatic.com/s/scada/v4/PCGyLT1qNawkOUQ3uHFhBw.ttf",
+    "700": "http://fonts.gstatic.com/s/scada/v4/t6XNWdMdVWUz93EuRVmifQ.ttf",
+    "700italic": "http://fonts.gstatic.com/s/scada/v4/kLrBIf7V4mDMwcd_Yw7-D_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Jura",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/jura/v7/Rqx_xy1UnN0C7wD3FUSyPQ.ttf",
+    "regular": "http://fonts.gstatic.com/s/jura/v7/YAWMwF3sN0KCbynMq-Yr_Q.ttf",
+    "500": "http://fonts.gstatic.com/s/jura/v7/16xhfjHCiaLj3tsqqgmtGg.ttf",
+    "600": "http://fonts.gstatic.com/s/jura/v7/iwseduOwJSdY8wQ1Y6CJdA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Pinyon Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pinyonscript/v6/TzghnhfCn7TuE73f-CBQ0CeUSrabuTpOsMEiRLtKwk0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gentium Book Basic",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gentiumbookbasic/v6/IRFxB2matTxrjZt6a3FUnrWDjKAyldGEr6eEi2MBNeY.ttf",
+    "italic": "http://fonts.gstatic.com/s/gentiumbookbasic/v6/qHqW2lwKO8-uTfIkh8FsUfXfjMwrYnmPVsQth2IcAPY.ttf",
+    "700": "http://fonts.gstatic.com/s/gentiumbookbasic/v6/T2vUYmWzlqUtgLYdlemGnaWESMHIjnSjm9UUxYtEOko.ttf",
+    "700italic": "http://fonts.gstatic.com/s/gentiumbookbasic/v6/632u7TMIoFDWQYUaHFUp5PA2A9KyRZEkn4TZVuhsWRM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Patrick Hand",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/patrickhand/v10/9BG3JJgt_HlF3NpEUehL0C3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Great Vibes",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/greatvibes/v4/4Mi5RG_9LjQYrTU55GN_L6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Changa One",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/changaone/v9/dr4qjce4W3kxFrZRkVD87fesZW2xOQ-xsNqO47m55DA.ttf",
+    "italic": "http://fonts.gstatic.com/s/changaone/v9/wJVQlUs1lAZel-WdTo2U9y3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fugaz One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fugazone/v6/5tteVDCwxsr8-5RuSiRWOw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Marvel",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/marvel/v6/Fg1dO8tWVb-MlyqhsbXEkg.ttf",
+    "italic": "http://fonts.gstatic.com/s/marvel/v6/HzyjFB-oR5usrc7Lxz9g8w.ttf",
+    "700": "http://fonts.gstatic.com/s/marvel/v6/WrHDBL1RupWGo2UcdgxB3Q.ttf",
+    "700italic": "http://fonts.gstatic.com/s/marvel/v6/Gzf5NT09Y6xskdQRj2kz1qCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Enriqueta",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/enriqueta/v5/_p90TrIwR1SC-vDKtmrv6A.ttf",
+    "700": "http://fonts.gstatic.com/s/enriqueta/v5/I27Pb-wEGH2ajLYP0QrtSC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Molengo",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/molengo/v7/jcjgeGuzv83I55AzOTpXNQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Amiri",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin",
+    "arabic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/amiri/v7/ATARrPmSew75SlpOw2YABQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/amiri/v7/3t1yTQlLUXBw8htrqlXBrw.ttf",
+    "700": "http://fonts.gstatic.com/s/amiri/v7/WQsR_moz-FNqVwGYgptqiA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/amiri/v7/uF8aNEyD0bxMeTBg9bFDSPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Voltaire",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/voltaire/v6/WvqBzaGEBbRV-hrahwO2cA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Playfair Display SC",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/playfairdisplaysc/v5/G0-tvBxd4eQRdwFKB8dRkcpjYTDWIvcAwAccqeW9uNM.ttf",
+    "italic": "http://fonts.gstatic.com/s/playfairdisplaysc/v5/myuYiFR-4NTrUT4w6TKls2klJsJYggW8rlNoTOTuau0.ttf",
+    "700": "http://fonts.gstatic.com/s/playfairdisplaysc/v5/5ggqGkvWJU_TtW2W8cEubA-Amcyomnuy4WsCiPxGHjw.ttf",
+    "700italic": "http://fonts.gstatic.com/s/playfairdisplaysc/v5/6X0OQrQhEEnPo56RalREX4krgPi80XvBcbTwmz-rgmU.ttf",
+    "900": "http://fonts.gstatic.com/s/playfairdisplaysc/v5/5ggqGkvWJU_TtW2W8cEubKXL3C32k275YmX_AcBPZ7w.ttf",
+    "900italic": "http://fonts.gstatic.com/s/playfairdisplaysc/v5/6X0OQrQhEEnPo56RalREX8Zag2q3ssKz8uH1RU4a9gs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Vidaloka",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/vidaloka/v8/C6Nul0ogKUWkx356rrt9RA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Marck Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/marckscript/v7/O_D1NAZVOFOobLbVtW3bci3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Actor",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/actor/v6/ugMf40CrRK6Jf6Yz_xNSmQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Luckiest Guy",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/luckiestguy/v6/5718gH8nDy3hFVihOpkY5C3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Domine",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/domine/v4/wfVIgamVFjMNQAEWurCiHA.ttf",
+    "700": "http://fonts.gstatic.com/s/domine/v4/phBcG1ZbQFxUIt18hPVxnw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Glegoo",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/glegoo/v5/2tf-h3n2A_SNYXEO0C8bKw.ttf",
+    "700": "http://fonts.gstatic.com/s/glegoo/v5/TlLolbauH0-0Aiz1LUH5og.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rambla",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rambla/v4/YaTmpvm5gFg_ShJKTQmdzg.ttf",
+    "italic": "http://fonts.gstatic.com/s/rambla/v4/mhUgsKmp0qw3uATdDDAuwA.ttf",
+    "700": "http://fonts.gstatic.com/s/rambla/v4/C5VZH8BxQKmnBuoC00UPpw.ttf",
+    "700italic": "http://fonts.gstatic.com/s/rambla/v4/ziMzUZya6QahrKONSI1TzqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Just Another Hand",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/justanotherhand/v7/fKV8XYuRNNagXr38eqbRf99BnJIEGrvoojniP57E51c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sorts Mill Goudy",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sortsmillgoudy/v6/JzRrPKdwEnE8F1TDmDLMUlIL2Qjg-Xlsg_fhGbe2P5U.ttf",
+    "italic": "http://fonts.gstatic.com/s/sortsmillgoudy/v6/UUu1lKiy4hRmBWk599VL1TYNkCNSzLyoucKmbTguvr0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Niconne",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/niconne/v6/ZA-mFw2QNXodx5y7kfELBg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Viga",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/viga/v5/uD87gDbhS7frHLX4uL6agg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Marmelad",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/marmelad/v6/jI0_FBlSOIRLL0ePWOhOwQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Homenaje",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/homenaje/v5/v0YBU0iBRrGdVjDNQILxtA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Squada One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/squadaone/v5/3tzGuaJdD65cZVgfQzN8uvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Audiowide",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/audiowide/v4/yGcwRZB6VmoYhPUYT-mEow.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Calligraffitti",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/calligraffitti/v7/vLVN2Y-z65rVu1R7lWdvyDXz_orj3gX0_NzfmYulrko.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Damion",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/damion/v6/13XtECwKxhD_VrOqXL4SiA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cantata One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cantataone/v5/-a5FDvnBqaBMDaGgZYnEfqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Basic",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/basic/v6/hNII2mS5Dxw5C0u_m3mXgA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Doppio One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/doppioone/v4/WHZ3HJQotpk_4aSMNBo_t_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Neuton",
+   "category": "serif",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "italic",
+    "700",
+    "800"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/neuton/v8/DA3Mkew3XqSkPpi1f4tJow.ttf",
+    "300": "http://fonts.gstatic.com/s/neuton/v8/xrc_aZ2hx-gdeV0mlY8Vww.ttf",
+    "regular": "http://fonts.gstatic.com/s/neuton/v8/9R-MGIOQUdjAVeB6nE6PcQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/neuton/v8/uVMT3JOB5BNFi3lgPp6kEg.ttf",
+    "700": "http://fonts.gstatic.com/s/neuton/v8/gnWpkWY7DirkKiovncYrfg.ttf",
+    "800": "http://fonts.gstatic.com/s/neuton/v8/XPzBQV4lY6enLxQG9cF1jw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Julius Sans One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-22",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/juliussansone/v5/iU65JP9acQHPDLkdalCF7jjVlsJB_M_Q_LtZxsoxvlw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Arapey",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/arapey/v5/dqu823lrSYn8T2gApTdslA.ttf",
+    "italic": "http://fonts.gstatic.com/s/arapey/v5/pY-Xi5JNBpaWxy2tZhEm5A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Days One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/daysone/v6/kzwZjNhc1iabMsrc_hKBIA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lusitana",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lusitana/v4/l1h9VDomkwbdzbPdmLcUIw.ttf",
+    "700": "http://fonts.gstatic.com/s/lusitana/v4/GWtZyUsONxgkdl3Mc1P7FKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cherry Cream Soda",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cherrycreamsoda/v6/OrD-AUnFcZeeKa6F_c0_WxOiHiuAPYA9ry3O1RG2XIU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bad Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/badscript/v5/cRyUs0nJ2eMQFHwBsZNRXfesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Electrolize",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/electrolize/v5/yFVu5iokC-nt4B1Cyfxb9aCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Limelight",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/limelight/v7/5dTfN6igsXjLjOy8QQShcg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Montez",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/montez/v6/kx58rLOWQQLGFM4pDHv5Ng.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Coda",
+   "category": "display",
+   "variants": [
+    "regular",
+    "800"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v11",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/coda/v11/yHDvulhg-P-p2KRgRrnUYw.ttf",
+    "800": "http://fonts.gstatic.com/s/coda/v11/6ZIw0sbALY0KTMWllZB3hQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ultra",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ultra/v8/OW8uXkOstRADuhEmGOFQLA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Contrail One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/contrailone/v6/b41KxjgiyqX-hkggANDU6C3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Copse",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/copse/v6/wikLrtPGjZDvZ5w2i5HLWg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Volkhov",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/volkhov/v8/MDIZAofe1T_J3un5Kgo8zg.ttf",
+    "italic": "http://fonts.gstatic.com/s/volkhov/v8/1rTjmztKEpbkKH06JwF8Yw.ttf",
+    "700": "http://fonts.gstatic.com/s/volkhov/v8/L8PbKS-kEoLHm7nP--NCzPesZW2xOQ-xsNqO47m55DA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/volkhov/v8/W6oG0QDDjCgj0gmsHE520C3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Allerta",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/allerta/v7/s9FOEuiJFTNbMe06ifzV8g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Syncopate",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/syncopate/v7/RQVwO52fAH6MI764EcaYtw.ttf",
+    "700": "http://fonts.gstatic.com/s/syncopate/v7/S5z8ixiOoC4WJ1im6jAlYC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Carme",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/carme/v7/08E0NP1eRBEyFRUadmMfgA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Acme",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/acme/v5/-J6XNtAHPZBEbsifCdBt-g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Homemade Apple",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/homemadeapple/v6/yg3UMEsefgZ8IHz_ryz86BiPOmFWYV1WlrJkRafc4c0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nothing You Could Do",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/nothingyoucoulddo/v6/jpk1K3jbJoyoK0XKaSyQAf-TpkXjXYGWiJZAEtBRjPU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Waiting for the Sunrise",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/waitingforthesunrise/v7/eNfH7kLpF1PZWpsetF-ha9TChrNgrDiT3Zy6yGf3FnM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Berkshire Swash",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/berkshireswash/v4/4RZJjVRPjYnC2939hKCAimKfbtsIjCZP_edQljX9gR0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Khula",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "600",
+    "700",
+    "800"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/khula/v1/_1LySU5Upq-sc4OZ1b_GIw.ttf",
+    "regular": "http://fonts.gstatic.com/s/khula/v1/izcPIFyCSd16XI1Ak_Wk7Q.ttf",
+    "600": "http://fonts.gstatic.com/s/khula/v1/4ZH86Hce-aeFDaedTnbkbg.ttf",
+    "700": "http://fonts.gstatic.com/s/khula/v1/UGVExGl-Jjs-YPpGv-MZ6w.ttf",
+    "800": "http://fonts.gstatic.com/s/khula/v1/Sccp_oOo8FWgbx5smie7xQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bubblegum Sans",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bubblegumsans/v5/Y9iTUUNz6lbl6TrvV4iwsytnKWgpfO2iSkLzTz-AABg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oleo Script",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/oleoscript/v5/21stZcmPyzbQVXtmGegyqKCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/oleoscript/v5/hudNQFKFl98JdNnlo363fne1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cutive",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cutive/v8/G2bW-ImyOCwKxBkLyz39YQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Reenie Beanie",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/reeniebeanie/v7/ljpKc6CdXusL1cnGUSamX4jjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Walter Turncoat",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/walterturncoat/v6/sG9su5g4GXy1KP73cU3hvQplL2YwNeota48DxFlGDUo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Overlock",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/overlock/v5/Z8oYsGi88-E1cUB8YBFMAg.ttf",
+    "italic": "http://fonts.gstatic.com/s/overlock/v5/rq6EacukHROOBrFrK_zF6_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/overlock/v5/Fexr8SqXM8Bm_gEVUA7AKaCWcynf_cDxXwCLxiixG1c.ttf",
+    "700italic": "http://fonts.gstatic.com/s/overlock/v5/wFWnYgeXKYBks6gEUwYnfAJKKGfqHaYFsRG-T3ceEVo.ttf",
+    "900": "http://fonts.gstatic.com/s/overlock/v5/YPJCVTT8ZbG3899l_-KIGqCWcynf_cDxXwCLxiixG1c.ttf",
+    "900italic": "http://fonts.gstatic.com/s/overlock/v5/iOZhxT2zlg7W5ij_lb-oDp0EAVxt0G0biEntp43Qt6E.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Jockey One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/jockeyone/v6/cAucnOZLvFo07w2AbufBCfesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nixie One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/nixieone/v7/h6kQfmzm0Shdnp3eswRaqQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Michroma",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/michroma/v7/0c2XrW81_QsiKV8T9thumA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Crafty Girls",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/craftygirls/v5/0Sv8UWFFdhQmesHL32H8oy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Share",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/share/v5/1ytD7zSb_-g9I2GG67vmVw.ttf",
+    "italic": "http://fonts.gstatic.com/s/share/v5/a9YGdQWFRlNJ0zClJVaY3Q.ttf",
+    "700": "http://fonts.gstatic.com/s/share/v5/XrU8e7a1YKurguyY2azk1Q.ttf",
+    "700italic": "http://fonts.gstatic.com/s/share/v5/A992-bLVYwAflKu6iaznufesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kameron",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kameron/v7/9r8HYhqDSwcq9WMjupL82A.ttf",
+    "700": "http://fonts.gstatic.com/s/kameron/v7/rabVVbzlflqvmXJUFlKnu_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alice",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alice/v7/wZTAfivekBqIg-rk63nFvQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gentium Basic",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gentiumbasic/v7/KCktj43blvLkhOTolFn-MYtBLojGU5Qdl8-5NL4v70w.ttf",
+    "italic": "http://fonts.gstatic.com/s/gentiumbasic/v7/qoFz4NSMaYC2UmsMAG3lyTj3mvXnCeAk09uTtmkJGRc.ttf",
+    "700": "http://fonts.gstatic.com/s/gentiumbasic/v7/2qL6yulgGf0wwgOp-UqGyLNuTeOOLg3nUymsEEGmdO0.ttf",
+    "700italic": "http://fonts.gstatic.com/s/gentiumbasic/v7/8N9-c_aQDJ8LbI1NGVMrwtswO1vWwP9exiF8s0wqW10.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fontdiner Swanky",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fontdinerswanky/v6/8_GxIO5ixMtn5P6COsF3TlBjMPLzPAFJwRBn-s1U7kA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Montserrat Alternates",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/montserratalternates/v4/z2n1Sjxk9souK3HCtdHuklPuEVRGaG9GCQnmM16YWq0.ttf",
+    "700": "http://fonts.gstatic.com/s/montserratalternates/v4/YENqOGAVzwIHjYNjmKuAZpeqBKvsAhm-s2I4RVSXFfc.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Yesteryear",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/yesteryear/v5/dv09hP_ZrdjVOfZQXKXuZvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Antic",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/antic/v7/hEa8XCNM7tXGzD0Uk0AipA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Aldrich",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/aldrich/v6/kMMW1S56gFx7RP_mW1g-Eg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Six Caps",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sixcaps/v7/_XeDnO0HOV8Er9u97If1tQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sacramento",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sacramento/v4/_kv-qycSHMNdhjiv0Kj7BvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Coustard",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "900"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/coustard/v6/iO2Rs5PmqAEAXoU3SkMVBg.ttf",
+    "900": "http://fonts.gstatic.com/s/coustard/v6/W02OCWO6OfMUHz6aVyegQ6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "PT Serif Caption",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ptserifcaption/v8/7xkFOeTxxO1GMC1suOUYWVsRioCqs5fohhaYel24W3k.ttf",
+    "italic": "http://fonts.gstatic.com/s/ptserifcaption/v8/0kfPsmrmTSgiec7u_Wa0DB1mqvzPHelJwRcF_s_EUM0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rochester",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rochester/v6/bnj8tmQBiOkdji_G_yvypg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Telex",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/telex/v4/24-3xP9ywYeHOcFU3iGk8A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Neucha",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/neucha/v8/bijdhB-TzQdtpl0ykhGh4Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oranienbaum",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/oranienbaum/v5/M98jYwCSn0PaFhXXgviCoaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ubuntu Mono",
+   "category": "monospace",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ubuntumono/v6/EgeuS9OtEmA0y_JRo03MQaCWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/ubuntumono/v6/KAKuHXAHZOeECOWAHsRKA0eOrDcLawS7-ssYqLr2Xp4.ttf",
+    "700": "http://fonts.gstatic.com/s/ubuntumono/v6/ceqTZGKHipo8pJj4molytne1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/ubuntumono/v6/n_d8tv_JOIiYyMXR4eaV9c_zJjSACmk0BRPxQqhnNLU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alegreya Sans SC",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "100italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "700",
+    "700italic",
+    "800",
+    "800italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/alegreyasanssc/v3/trwFkDJLOJf6hqM93944kVnzStfdnFU-MXbO84aBs_M.ttf",
+    "100italic": "http://fonts.gstatic.com/s/alegreyasanssc/v3/qG3gA9iy5RpXMH4crZboqqakMVR0XlJhO7VdJ8yYvA4.ttf",
+    "300": "http://fonts.gstatic.com/s/alegreyasanssc/v3/AjAmkoP1y0Vaad0UPPR46-1IqtfxJspFjzJp0SaQRcI.ttf",
+    "300italic": "http://fonts.gstatic.com/s/alegreyasanssc/v3/0VweK-TO3aQgazdxg8fs0CnTKaH808trtzttbEg4yVA.ttf",
+    "regular": "http://fonts.gstatic.com/s/alegreyasanssc/v3/6kgb6ZvOagoVIRZyl8XV-EklWX-XdLVn1WTiuGuvKIU.ttf",
+    "italic": "http://fonts.gstatic.com/s/alegreyasanssc/v3/trwFkDJLOJf6hqM93944kTfqo69HNOlCNZvbwAmUtiA.ttf",
+    "500": "http://fonts.gstatic.com/s/alegreyasanssc/v3/AjAmkoP1y0Vaad0UPPR46_hHTluI57wqxl55RvSYo3s.ttf",
+    "500italic": "http://fonts.gstatic.com/s/alegreyasanssc/v3/0VweK-TO3aQgazdxg8fs0NqVvxKdFVwqwzilqfVd39U.ttf",
+    "700": "http://fonts.gstatic.com/s/alegreyasanssc/v3/AjAmkoP1y0Vaad0UPPR4600aId5t1FC-xZ8nmpa_XLk.ttf",
+    "700italic": "http://fonts.gstatic.com/s/alegreyasanssc/v3/0VweK-TO3aQgazdxg8fs0IBYn3VD6xMEnodOh8pnFw4.ttf",
+    "800": "http://fonts.gstatic.com/s/alegreyasanssc/v3/AjAmkoP1y0Vaad0UPPR46wQgSHD3Lo1Mif2Wkk5swWA.ttf",
+    "800italic": "http://fonts.gstatic.com/s/alegreyasanssc/v3/0VweK-TO3aQgazdxg8fs0HStmCm6Rs90XeztCALm0H8.ttf",
+    "900": "http://fonts.gstatic.com/s/alegreyasanssc/v3/AjAmkoP1y0Vaad0UPPR461Rf9EWUSEX_PR1d_gLKfpM.ttf",
+    "900italic": "http://fonts.gstatic.com/s/alegreyasanssc/v3/0VweK-TO3aQgazdxg8fs0IvtwEfTCJoOJugANj-jWDI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cabin Sketch",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cabinsketch/v8/d9fijO34zQajqQvl3YHRCS3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/cabinsketch/v8/ki3SSN5HMOO0-IOLOj069ED2ttfZwueP-QU272T9-k4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Goudy Bookletter 1911",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/goudybookletter1911/v6/l5lwlGTN3pEY5Bf-rQEuIIjNDsyURsIKu4GSfvSE4mA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Aclonica",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/aclonica/v6/M6pHZMPwK3DiBSlo3jwAKQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Trocchi",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/trocchi/v4/uldNPaKrUGVeGCVsmacLwA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Boogaloo",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/boogaloo/v6/4Wu1tvFMoB80fSu8qLgQfQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fredericka the Great",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/frederickathegreat/v5/7Es8Lxoku-e5eOZWpxw18nrnet6gXN1McwdQxS1dVrI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sansita One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sansitaone/v6/xWqf68oB50JXqGIRR0h2hqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Spinnaker",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/spinnaker/v8/MQdIXivKITpjROUdiN6Jgg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alex Brush",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alexbrush/v6/ooh3KJFbKJSUoIRWfiu8o_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Quantico",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/quantico/v5/pwSnP8Xpaix2rIz99HrSlQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/quantico/v5/KQhDd2OsZi6HiITUeFQ2U_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/quantico/v5/OVZZzjcZ3Hkq2ojVcUtDjaCWcynf_cDxXwCLxiixG1c.ttf",
+    "700italic": "http://fonts.gstatic.com/s/quantico/v5/HeCYRcZbdRso3ZUu01ELbQJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Prata",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/prata/v6/3gmx8r842loRRm9iQkCDGg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Denk One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/denkone/v4/TdXOeA4eA_hEx4W8Sh9wPw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Average",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/average/v4/aHUibBqdDbVYl5FM48pxyQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gochi Hand",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gochihand/v7/KT1-WxgHsittJ34_20IfAPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mako",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mako/v7/z5zSLmfPlv1uTVAdmJBLXg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lilita One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lilitaone/v4/vTxJQjbNV6BCBHx8sGDCVvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Adamina",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/adamina/v7/RUQfOodOMiVVYqFZcSlT9w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rancho",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rancho/v6/ekp3-4QykC4--6KaslRgHA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ceviche One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cevicheone/v6/WOaXIMBD4VYMy39MsobJhKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Allerta Stencil",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/allertastencil/v7/CdSZfRtHbQrBohqmzSdDYFf2eT4jUldwg_9fgfY_tHc.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mallanna",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mallanna/v4/krCTa-CfMbtxqF0689CbuQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Belleza",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/belleza/v4/wchA3BWJlVqvIcSeNZyXew.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rajdhani",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/rajdhani/v5/9pItuEhQZVGdq8spnHTku6CWcynf_cDxXwCLxiixG1c.ttf",
+    "regular": "http://fonts.gstatic.com/s/rajdhani/v5/Wfy5zp4PGFAFS7-Wetehzw.ttf",
+    "500": "http://fonts.gstatic.com/s/rajdhani/v5/nd_5ZpVwm710HcLual0fBqCWcynf_cDxXwCLxiixG1c.ttf",
+    "600": "http://fonts.gstatic.com/s/rajdhani/v5/5fnmZahByDeTtgxIiqbJSaCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/rajdhani/v5/UBK6d2Hg7X7wYLlF92aXW6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Allura",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/allura/v4/4hcqgZanyuJ2gMYWffIR6A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Schoolbell",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/schoolbell/v6/95-3djEuubb3cJx-6E7j4vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Radley",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/radley/v9/FgE9di09a-mXGzAIyI6Q9Q.ttf",
+    "italic": "http://fonts.gstatic.com/s/radley/v9/Z_JcACuPAOO2f9kzQcGRug.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Freckle Face",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/freckleface/v4/7-B8j9BPJgazdHIGqPNv8y3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rosario",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rosario/v10/bL-cEh8dXtDupB2WccA2LA.ttf",
+    "italic": "http://fonts.gstatic.com/s/rosario/v10/pkflNy18HEuVVx4EOjeb_Q.ttf",
+    "700": "http://fonts.gstatic.com/s/rosario/v10/nrS6PJvDWN42RP4TFWccd_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/rosario/v10/EOgFX2Va5VGrkhn_eDpIRS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Frijole",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/frijole/v5/L2MfZse-2gCascuD-nLhWg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Yellowtail",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/yellowtail/v6/HLrU6lhCTjXfLZ7X60LcB_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Puritan",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/puritan/v8/wv_RtgVBSCn-or2MC0n4Kg.ttf",
+    "italic": "http://fonts.gstatic.com/s/puritan/v8/BqZX8Tp200LeMv1KlzXgLQ.ttf",
+    "700": "http://fonts.gstatic.com/s/puritan/v8/pJS2SdwI0SCiVnO0iQSFT_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/puritan/v8/rFG3XkMJL75nUNZwCEIJqC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Slackey",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/slackey/v6/evRIMNhGVCRJvCPv4kteeA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Inder",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/inder/v5/C38TwecLTfKxIHDc_Adcrw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Allan",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/allan/v7/T3lemhgZmLQkQI2Qc2bQHA.ttf",
+    "700": "http://fonts.gstatic.com/s/allan/v7/zSxQiwo7wgnr7KkMXhSiag.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Hanuman",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-08-26",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/hanuman/v9/hRhwOGGmElJSl6KSPvEnOQ.ttf",
+    "700": "http://fonts.gstatic.com/s/hanuman/v9/lzzXZ2l84x88giDrbfq76vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Magra",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/magra/v4/hoZ13bwCXBxuGZqAudgc5A.ttf",
+    "700": "http://fonts.gstatic.com/s/magra/v4/6fOM5sq5cIn8D0RjX8Lztw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Port Lligat Slab",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/portlligatslab/v5/CUEdhRk7oC7up0p6t0g4PxLSPACXvawUYCBEnHsOe30.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Arbutus Slab",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/arbutusslab/v4/6k3Yp6iS9l4jRIpynA8qMy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Iceland",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/iceland/v5/kq3uTMGgvzWGNi39B_WxGA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Black Ops One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/blackopsone/v7/2XW-DmDsGbDLE372KrMW1Yjjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Unica One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/unicaone/v4/KbYKlhWMDpatWViqDkNQgA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fanwood Text",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fanwoodtext/v6/hDNDHUlsSb8bgnEmDp4T_i3USBnSvpkopQaUR-2r7iU.ttf",
+    "italic": "http://fonts.gstatic.com/s/fanwoodtext/v6/0J3SBbkMZqBV-3iGxs5E9_MZXuCXbOrAvx5R0IT5Oyo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Press Start 2P",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pressstart2p/v4/8Lg6LX8-ntOHUQnvQ0E7o1jfl3W46Sz5gOkEVhcFWF4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Racing Sans One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/racingsansone/v4/1r3DpWaCiT7y3PD4KgkNyDjVlsJB_M_Q_LtZxsoxvlw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Forum",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/forum/v7/MZUpsq1VfLrqv8eSDcbrrQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cinzel Decorative",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cinzeldecorative/v4/fmgK7oaJJIXAkhd9798yQgT5USbJx2F82lQbogPy2bY.ttf",
+    "700": "http://fonts.gstatic.com/s/cinzeldecorative/v4/pXhIVnhFtL_B9Vb1wq2F95-YYVDmZkJErg0zgx9XuZI.ttf",
+    "900": "http://fonts.gstatic.com/s/cinzeldecorative/v4/pXhIVnhFtL_B9Vb1wq2F97Khqbv0zQZa0g-9HOXAalU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Marcellus",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/marcellus/v4/UjiLZzumxWC9whJ86UtaYw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Parisienne",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/parisienne/v4/TW74B5QISJNx9moxGlmJfvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tenor Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tenorsans/v7/dUBulmjNJJInvK5vL7O9yfesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alef",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "hebrew",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-08",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alef/v5/ENvZ_P0HBDQxNZYCQO0lUA.ttf",
+    "700": "http://fonts.gstatic.com/s/alef/v5/VDgZJhEwudtOzOFQpZ8MEA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alegreya SC",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alegreyasc/v6/3ozeFnTbygMK6PfHh8B-iqCWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/alegreyasc/v6/GOqmv3FLsJ2r6ZALMZVBmkeOrDcLawS7-ssYqLr2Xp4.ttf",
+    "700": "http://fonts.gstatic.com/s/alegreyasc/v6/M9OIREoxDkvynwTpBAYUq3e1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/alegreyasc/v6/5PCoU7IUfCicpKBJtBmP6c_zJjSACmk0BRPxQqhnNLU.ttf",
+    "900": "http://fonts.gstatic.com/s/alegreyasc/v6/M9OIREoxDkvynwTpBAYUqyenaqEuufTBk9XMKnKmgDA.ttf",
+    "900italic": "http://fonts.gstatic.com/s/alegreyasc/v6/5PCoU7IUfCicpKBJtBmP6U_yTOUGsoC54csJe1b-IRw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "PT Mono",
+   "category": "monospace",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ptmono/v4/QUbM8H9yJK5NhpQ0REO6Wg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Metrophobic",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/metrophobic/v6/SaglWZWCrrv_D17u1i4v_aCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ek Mukta",
+   "category": "sans-serif",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/ekmukta/v7/crtkNHh5JcM3VJKG0E-B36CWcynf_cDxXwCLxiixG1c.ttf",
+    "300": "http://fonts.gstatic.com/s/ekmukta/v7/mpaAv7CIyk0VnZlqSneVxKCWcynf_cDxXwCLxiixG1c.ttf",
+    "regular": "http://fonts.gstatic.com/s/ekmukta/v7/aFcjXdC5jyJ1p8w54wIIrg.ttf",
+    "500": "http://fonts.gstatic.com/s/ekmukta/v7/PZ1y2MstFczWvBlFSgzMyaCWcynf_cDxXwCLxiixG1c.ttf",
+    "600": "http://fonts.gstatic.com/s/ekmukta/v7/Z5Mfzeu6M3emakcJO2QeTqCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/ekmukta/v7/4ugcOGR28Jn-oBIn0-qLYaCWcynf_cDxXwCLxiixG1c.ttf",
+    "800": "http://fonts.gstatic.com/s/ekmukta/v7/O68TH5OjEhVmn9_gIrcfS6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gilda Display",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gildadisplay/v4/8yAVUZLLZ3wb7dSsjix0CADHmap7fRWINAsw8-RaxNg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Marcellus SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/marcellussc/v4/_jugwxhkkynrvsfrxVx8gS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Duru Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-07-30",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/durusans/v9/xn7iYH8xwmSyTvEV_HOxTw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lustria",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lustria/v4/gXAk0s4ai0X-TAOhYzZd1w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gruppo",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gruppo/v7/pS_JM0cK_piBZve-lfUq9w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Graduate",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/graduate/v4/JpAmYLHqcIh9_Ff35HHwiA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tauri",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tauri/v4/XIWeYJDXNqiVNej0zEqtGg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Knewave",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/knewave/v5/KGHM4XWr4iKnBMqzZLkPBg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Convergence",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/convergence/v5/eykrGz1NN_YpQmkAZjW-qKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chelsea Market",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chelseamarket/v4/qSdzwh2A4BbNemy78sJLfAAI1i8fIftCBXsBF2v9UMI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Capriola",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/capriola/v4/JxXPlkdzWwF9Cwelbvi9jA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alike",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alike/v7/Ho8YpRKNk_202fwDiGNIyw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Halant",
+   "category": "serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-01",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/halant/v1/dM3ItAOWNNod_Cf3MnLlEg.ttf",
+    "regular": "http://fonts.gstatic.com/s/halant/v1/rEs7Jk3SVyt3cTx6DoTu1w.ttf",
+    "500": "http://fonts.gstatic.com/s/halant/v1/tlsNj3K-hJKtiirTDtUbkQ.ttf",
+    "600": "http://fonts.gstatic.com/s/halant/v1/zNR2WvI_V8o652vIZp3X4Q.ttf",
+    "700": "http://fonts.gstatic.com/s/halant/v1/D9FN7OH89AuCmZDLHbPQfA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Petit Formal Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/petitformalscript/v4/OEZwr2-ovBsq2n3ACCKoEvVPl2Gjtxj0D6F7QLy1VQc.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Average Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/averagesans/v4/dnU3R-5A_43y5bIyLztPsS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Voces",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/voces/v4/QoBH6g6yKgNIgvL8A2aE2Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kotta One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kottaone/v4/AB2Q7hVw6niJYDgLvFXu5w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Baumans",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/baumans/v5/o0bFdPW1H5kd5saqqOcoVg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Just Me Again Down Here",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/justmeagaindownhere/v8/sN06iTc9ITubLTgXoG-kc3M9eVLpVTSK6TqZTIgBrWQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Finger Paint",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fingerpaint/v4/m_ZRbiY-aPb13R3DWPBGXy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Italianno",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/italianno/v6/HsyHnLpKf8uP7aMpDQHZmg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Unkempt",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/unkempt/v7/NLLBeNSspr0RGs71R5LHWA.ttf",
+    "700": "http://fonts.gstatic.com/s/unkempt/v7/V7H-GCl9bgwGwqFqTTgDHvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "The Girl Next Door",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/thegirlnextdoor/v7/cWRA4JVGeEcHGcPl5hmX7kzo0nFFoM60ux_D9BUymX4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Carter One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/carterone/v8/5X_LFvdbcB7OBG7hBgZ7fPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Square",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novasquare/v8/BcBzXoaDzYX78rquGXVuSqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Grand Hotel",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/grandhotel/v4/C_A8HiFZjXPpnMt38XnK7qCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cousine",
+   "category": "monospace",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "hebrew",
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-28",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cousine/v10/GYX4bPXObJNJo63QJEUnLg.ttf",
+    "italic": "http://fonts.gstatic.com/s/cousine/v10/1WtIuajLoo8vjVwsrZ3eOg.ttf",
+    "700": "http://fonts.gstatic.com/s/cousine/v10/FXEOnNUcCzhdtoBxiq-lovesZW2xOQ-xsNqO47m55DA.ttf",
+    "700italic": "http://fonts.gstatic.com/s/cousine/v10/y_AZ5Sz-FwL1lux2xLSTZS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Caudex",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "greek-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/caudex/v6/PWEexiHLDmQbn2b1OPZWfg.ttf",
+    "italic": "http://fonts.gstatic.com/s/caudex/v6/XjMZF6XCisvV3qapD4oJdw.ttf",
+    "700": "http://fonts.gstatic.com/s/caudex/v6/PetCI4GyQ5Q3LiOzUu_mMg.ttf",
+    "700italic": "http://fonts.gstatic.com/s/caudex/v6/yT8YeHLjaJvQXlUEYOA8gqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fenix",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fenix/v4/Ak8wR3VSlAN7VN_eMeJj7Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell English",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfellenglish/v6/xwIisCqGFi8pff-oa9uSVHGNmx1fDm-u2eBJHQkdrmk.ttf",
+    "italic": "http://fonts.gstatic.com/s/imfellenglish/v6/Z3cnIAI_L3XTRfz4JuZKbuewladMPCWTthtMv9cPS-c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Caesar Dressing",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/caesardressing/v5/2T_WzBgE2Xz3FsyJMq34T9gR43u4FvCuJwIfF5Zxl6Y.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rufina",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rufina/v4/s9IFr_fIemiohfZS-ZRDbQ.ttf",
+    "700": "http://fonts.gstatic.com/s/rufina/v4/D0RUjXFr55y4MVZY2Ww_RA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Leckerli One",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/leckerlione/v7/S2Y_iLrItTu8kIJTkS7DrC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Merienda",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/merienda/v4/MYY6Og1qZlOQtPW2G95Y3A.ttf",
+    "700": "http://fonts.gstatic.com/s/merienda/v4/GlwcvRLlgiVE2MBFQ4r0sKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Roboto Mono",
+   "category": "monospace",
+   "variants": [
+    "100",
+    "100italic",
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "greek",
+    "greek-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-05-28",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/robotomono/v4/aOIeRp72J9_Hp_8KwQ9M-YAWxXGWZ3yJw6KhWS7MxOk.ttf",
+    "100italic": "http://fonts.gstatic.com/s/robotomono/v4/rqQ1zSE-ZGCKVZgew-A9dgyDtfpXZi-8rXUZYR4dumU.ttf",
+    "300": "http://fonts.gstatic.com/s/robotomono/v4/N4duVc9C58uwPiY8_59Fzy9-WlPSxbfiI49GsXo3q0g.ttf",
+    "300italic": "http://fonts.gstatic.com/s/robotomono/v4/1OsMuiiO6FCF2x67vzDKA2o9eWDfYYxG3A176Zl7aIg.ttf",
+    "regular": "http://fonts.gstatic.com/s/robotomono/v4/eJ4cxQe85Lo39t-LVoKa26CWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/robotomono/v4/mE0EPT_93c7f86_WQexR3EeOrDcLawS7-ssYqLr2Xp4.ttf",
+    "500": "http://fonts.gstatic.com/s/robotomono/v4/N4duVc9C58uwPiY8_59Fz8CNfqCYlB_eIx7H1TVXe60.ttf",
+    "500italic": "http://fonts.gstatic.com/s/robotomono/v4/1OsMuiiO6FCF2x67vzDKA2nWRcJAYo5PSCx8UfGMHCI.ttf",
+    "700": "http://fonts.gstatic.com/s/robotomono/v4/N4duVc9C58uwPiY8_59Fz3e1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "700italic": "http://fonts.gstatic.com/s/robotomono/v4/1OsMuiiO6FCF2x67vzDKA8_zJjSACmk0BRPxQqhnNLU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Londrina Solid",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/londrinasolid/v4/yysorIEiYSBb0ylZjg791MR125CwGqh8XBqkBzea0LA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Annie Use Your Telescope",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/annieuseyourtelescope/v6/2cuiO5VmaR09C8SLGEQjGqbp7mtG8sPlcZvOaO8HBak.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Belgrano",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/belgrano/v6/iq8DUa2s7g6WRCeMiFrmtQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kelly Slab",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kellyslab/v6/F_2oS1e9XdYx1MAi8XEVefesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "VT323",
+   "category": "monospace",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/vt323/v7/ITU2YQfM073o1iYK3nSOmQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Crushed",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/crushed/v6/aHwSejs3Kt0Lg95u7j32jA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lily Script One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lilyscriptone/v4/uPWsLVW8uiXqIBnE8ZwGPDjVlsJB_M_Q_LtZxsoxvlw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sue Ellen Francisco",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sueellenfrancisco/v7/TwHX4vSxMUnJUdEz1JIgrhzazJzPVbGl8jnf1tisRz4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Judson",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-31",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/judson/v8/znM1AAs0eytUaJzf1CrYZQ.ttf",
+    "italic": "http://fonts.gstatic.com/s/judson/v8/GVqQW9P52ygW-ySq-CLwAA.ttf",
+    "700": "http://fonts.gstatic.com/s/judson/v8/he4a2LwiPJc7r8x0oKCKiA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Timmana",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/timmana/v1/T25SicsJUJkc2s2sbBsDnA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell DW Pica",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfelldwpica/v6/W81bfaWiUicLSPbJhW-ATsA5qm663gJGVdtpamafG5A.ttf",
+    "italic": "http://fonts.gstatic.com/s/imfelldwpica/v6/alQJ8SK5aSOZVaelYoyT4PL2asmh5DlYQYCosKo6yQs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Anaheim",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/anaheim/v4/t-z8aXHMpgI2gjN_rIflKA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Imprima",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imprima/v4/eRjquWLjwLGnTEhLH7u3kA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Love Ya Like A Sister",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/loveyalikeasister/v7/LzkxWS-af0Br2Sk_YgSJY-ad1xEP8DQfgfY8MH9aBUg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Delius",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/delius/v6/TQA163qafki2-gV-B6F_ag.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lemon",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lemon/v5/wed1nNu4LNSu-3RoRVUhUw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Simonetta",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/simonetta/v5/fN8puNuahBo4EYMQgp12Yg.ttf",
+    "italic": "http://fonts.gstatic.com/s/simonetta/v5/ynxQ3FqfF_Nziwy3T9ZwL6CWcynf_cDxXwCLxiixG1c.ttf",
+    "900": "http://fonts.gstatic.com/s/simonetta/v5/22EwvvJ2r1VwVCxit5LcVi3USBnSvpkopQaUR-2r7iU.ttf",
+    "900italic": "http://fonts.gstatic.com/s/simonetta/v5/WUXOpCgBZaRPrWtMCpeKoienaqEuufTBk9XMKnKmgDA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sarala",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-17",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sarala/v1/ohip9lixCHoBab7hTtgLnw.ttf",
+    "700": "http://fonts.gstatic.com/s/sarala/v1/hpc9cz8KYsazwq2In_oJYw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Merienda One",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/meriendaone/v7/bCA-uDdUx6nTO8SjzCLXvS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bentham",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bentham/v6/5-Mo8Fe7yg5tzV0GlQIuzQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Corben",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/corben/v9/tTysMZkt-j8Y5yhkgsoajQ.ttf",
+    "700": "http://fonts.gstatic.com/s/corben/v9/lirJaFSQWdGQuV--fksg5g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rubik One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-07-22",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rubikone/v4/Zs6TtctNRSIR8T5PO018rQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Andika",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/andika/v6/oe-ag1G0lcqZ3IXfeEgaGg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ovo",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ovo/v7/mFg27dimu3s9t09qjCwB1g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kalam",
+   "category": "handwriting",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/kalam/v7/MgQQlk1SgPEHdlkWMNh7Jg.ttf",
+    "regular": "http://fonts.gstatic.com/s/kalam/v7/hNEJkp2K-aql7e5WQish4Q.ttf",
+    "700": "http://fonts.gstatic.com/s/kalam/v7/95nLItUGyWtNLZjSckluLQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Work Sans",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v2",
+   "lastModified": "2015-08-26",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/worksans/v2/ZAhtNqLaAViKjGLajtuwWaCWcynf_cDxXwCLxiixG1c.ttf",
+    "200": "http://fonts.gstatic.com/s/worksans/v2/u_mYNr_qYP37m7vgvmIYZy3USBnSvpkopQaUR-2r7iU.ttf",
+    "300": "http://fonts.gstatic.com/s/worksans/v2/FD_Udbezj8EHXbdsqLUply3USBnSvpkopQaUR-2r7iU.ttf",
+    "regular": "http://fonts.gstatic.com/s/worksans/v2/zVvigUiMvx7JVEnrJgc-5Q.ttf",
+    "500": "http://fonts.gstatic.com/s/worksans/v2/Nbre-U_bp6Xktt8cpgwaJC3USBnSvpkopQaUR-2r7iU.ttf",
+    "600": "http://fonts.gstatic.com/s/worksans/v2/z9rX03Xuz9ZNHTMg1_ghGS3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/worksans/v2/4udXuXg54JlPEP5iKO5AmS3USBnSvpkopQaUR-2r7iU.ttf",
+    "800": "http://fonts.gstatic.com/s/worksans/v2/IQh-ap2Uqs7kl1YINeeEGi3USBnSvpkopQaUR-2r7iU.ttf",
+    "900": "http://fonts.gstatic.com/s/worksans/v2/Hjn0acvjHfjY_vAK9Uc6gi3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Give You Glory",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/giveyouglory/v6/DFEWZFgGmfseyIdGRJAxuBwwkpSPZdvjnMtysdqprfI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Seaweed Script",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/seaweedscript/v4/eorWAPpOvvWrPw5IHwE60BnpV0hQCek3EmWnCPrvGRM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Orienta",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/orienta/v4/_NKSk93mMs0xsqtfjCsB3Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Brawler",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/brawler/v6/3gfSw6imxQnQxweVITqUrg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Megrim",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/megrim/v7/e-9jVUC9lv1zxaFQARuftw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lekton",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lekton/v7/r483JYmxf5PjIm4jVAm8Yg.ttf",
+    "italic": "http://fonts.gstatic.com/s/lekton/v7/_UbDIPBA1wDqSbhp-OED7A.ttf",
+    "700": "http://fonts.gstatic.com/s/lekton/v7/WZw-uL8WTkx3SBVfTlevXQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Khand",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/khand/v4/072zRl4OU9Pinjjkg174LA.ttf",
+    "regular": "http://fonts.gstatic.com/s/khand/v4/HdLdTNFqNIDGJZl1ZEj84w.ttf",
+    "500": "http://fonts.gstatic.com/s/khand/v4/46_p-SqtuMe56nxQdteWxg.ttf",
+    "600": "http://fonts.gstatic.com/s/khand/v4/zggGWYIiPJyMTgkfxP_kaA.ttf",
+    "700": "http://fonts.gstatic.com/s/khand/v4/0I0UWaN-X5QBmfexpXKhqg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bowlby One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bowlbyone/v7/eKpHjHfjoxM2bX36YNucefesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Shanti",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/shanti/v8/lc4nG_JG6Q-2FQSOMMhb_w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Quando",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/quando/v4/03nDiEZuO2-h3xvtG6UmHg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oxygen Mono",
+   "category": "monospace",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/oxygenmono/v4/DigTu7k4b7OmM8ubt1Qza6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Poly",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/poly/v7/bcMAuiacS2qkd54BcwW6_Q.ttf",
+    "italic": "http://fonts.gstatic.com/s/poly/v7/Zkx-eIlZSjKUrPGYhV5PeA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Strait",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/strait/v4/m4W73ViNmProETY2ybc-Bg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gravitas One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gravitasone/v6/nBHdBv6zVNU8MtP6w9FwTS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mr De Haviland",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mrdehaviland/v5/fD8y4L6PJ4vqDk7z8Y8e27v4lrhng1lzu7-weKO6cw8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Monoton",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/monoton/v6/aCz8ja_bE4dg-7agSvExdw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "GFS Didot",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "greek"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gfsdidot/v6/jQKxZy2RU-h9tkPZcRVluA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Pompiere",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pompiere/v6/o_va2p9CD5JfmFohAkGZIA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Happy Monkey",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/happymonkey/v5/c2o0ps8nkBmaOYctqBq1rS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Salsa",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/salsa/v6/BnpUCBmYdvggScEPs5JbpA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Wire One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/wireone/v6/sRLhaQOQpWnvXwIx0CycQw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kranky",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kranky/v6/C8dxxTS99-fZ84vWk8SDrg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Qwigley",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/qwigley/v6/aDqxws-KubFID85TZHFouw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fjord One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fjordone/v5/R_YHK8au2uFPw5tNu5N7zw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Headland One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/headlandone/v4/iGmBeOvQGfq9DSbjJ8jDVy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tienne",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tienne/v8/-IIfDl701C0z7-fy2kmGvA.ttf",
+    "700": "http://fonts.gstatic.com/s/tienne/v8/JvoCDOlyOSEyYGRwCyfs3g.ttf",
+    "900": "http://fonts.gstatic.com/s/tienne/v8/FBano5T521OWexj2iRYLMw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Norican",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/norican/v4/SHnSqhYAWG5sZTWcPzEHig.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "La Belle Aurore",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/labelleaurore/v7/Irdbc4ASuUoWDjd_Wc3md123K2iuuhwZgaKapkyRTY8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Khmer",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/khmer/v9/vWaBJIbaQuBNz02ALIKJ3A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mystery Quest",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mysteryquest/v4/467jJvg0c7HgucvBB9PLDyeUSrabuTpOsMEiRLtKwk0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Anonymous Pro",
+   "category": "monospace",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/anonymouspro/v8/Zhfjj_gat3waL4JSju74E-V_5zh5b-_HiooIRUBwn1A.ttf",
+    "italic": "http://fonts.gstatic.com/s/anonymouspro/v8/q0u6LFHwttnT_69euiDbWKwIsuKDCXG0NQm7BvAgx-c.ttf",
+    "700": "http://fonts.gstatic.com/s/anonymouspro/v8/WDf5lZYgdmmKhO8E1AQud--Cz_5MeePnXDAcLNWyBME.ttf",
+    "700italic": "http://fonts.gstatic.com/s/anonymouspro/v8/_fVr_XGln-cetWSUc-JpfA1LL9bfs7wyIp6F8OC9RxA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Teko",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/teko/v5/OobFGE9eo24rcBpN6zXDaQ.ttf",
+    "regular": "http://fonts.gstatic.com/s/teko/v5/UtekqODEqZXSN2L-njejpA.ttf",
+    "500": "http://fonts.gstatic.com/s/teko/v5/FQ0duU7gWM4cSaImOfAjBA.ttf",
+    "600": "http://fonts.gstatic.com/s/teko/v5/QDx_i8H-TZ1IK1JEVrqwEQ.ttf",
+    "700": "http://fonts.gstatic.com/s/teko/v5/xKfTxe_SWpH4xU75vmvylA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Slabo 13px",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/slabo13px/v3/jPGWFTjRXfCSzy0qd1nqdvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Titan One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/titanone/v4/FbvpRvzfV_oipS0De3iAZg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Skranji",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/skranji/v4/jnOLPS0iZmDL7dfWnW3nIw.ttf",
+    "700": "http://fonts.gstatic.com/s/skranji/v4/Lcrhg-fviVkxiEgoadsI1vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Zeyada",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/zeyada/v6/hmonmGYYFwqTZQfG2nRswQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Creepster",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/creepster/v5/0vdr5kWJ6aJlOg5JvxnXzQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Carrois Gothic SC",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/carroisgothicsc/v4/bVp4nhwFIXU-r3LqUR8DSJTdPW1ioadGi2uRiKgJVCY.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Trade Winds",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tradewinds/v5/sDOCVgAxw6PEUi2xdMsoDaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Short Stack",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/shortstack/v6/v4dXPI0Rm8XN9gk4SDdqlqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oregano",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/oregano/v4/UiLhqNixVv2EpjRoBG6axA.ttf",
+    "italic": "http://fonts.gstatic.com/s/oregano/v4/_iwqGEht6XsAuEaCbYG64Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Averia Gruesa Libre",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/averiagruesalibre/v4/10vbZTOoN6T8D-nvDzwRFyXcKHuZXlCN8VkWHpkUzKM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Englebert",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/englebert/v4/sll38iOvOuarDTYBchlP3Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oleo Script Swash Caps",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/oleoscriptswashcaps/v4/vdWhGqsBUAP-FF3NOYTe4iMF4kXAPemmyaDpMXQ31P0.ttf",
+    "700": "http://fonts.gstatic.com/s/oleoscriptswashcaps/v4/HMO3ftxA9AU5floml9c755reFYaXZ4zuJXJ8fr8OO1g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Amethysta",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/amethysta/v4/1jEo9tOFIJDolAUpBnWbnA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Loved by the King",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lovedbytheking/v6/wg03xD4cWigj4YDufLBSr8io2AFEwwMpu7y5KyiyAJc.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cedarville Cursive",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cedarvillecursive/v7/cuCe6HrkcqrWTWTUE7dw-41zwq9-z_Lf44CzRAA0d0Y.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Share Tech",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sharetech/v4/Dq3DuZ5_0SW3oEfAWFpen_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Paprika",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/paprika/v4/b-VpyoRSieBdB5BPJVF8HQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gafata",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gafata/v5/aTFqlki_3Dc3geo-FxHTvQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Patrick Hand SC",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/patrickhandsc/v4/OYFWCgfCR-7uHIovjUZXsbAgSRh1LpJXlLfl8IbsmHg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mountains of Christmas",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mountainsofchristmas/v8/dVGBFPwd6G44IWDbQtPew2Auds3jz1Fxb61CgfaGDr4.ttf",
+    "700": "http://fonts.gstatic.com/s/mountainsofchristmas/v8/PymufKtHszoLrY0uiAYKNM9cPTbSBTrQyTa5TWAe3vE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Andada",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/andada/v7/rSFaDqNNQBRw3y19MB5Y4w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Clicker Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/clickerscript/v4/Zupmk8XwADjufGxWB9KThBnpV0hQCek3EmWnCPrvGRM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Prosto One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/prostoone/v5/bsqnAElAqk9kX7eABTRFJPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Expletus Sans",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "600",
+    "600italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/expletussans/v8/gegTSDBDs5le3g6uxU1ZsX8f0n03UdmQgF_CLvNR2vg.ttf",
+    "italic": "http://fonts.gstatic.com/s/expletussans/v8/Y-erXmY0b6DU_i2Qu0hTJj4G9C9ttb0Oz5Cvf0qOitE.ttf",
+    "500": "http://fonts.gstatic.com/s/expletussans/v8/cl6rhMY77Ilk8lB_uYRRwAqQmZ7VjhwksfpNVG0pqGc.ttf",
+    "500italic": "http://fonts.gstatic.com/s/expletussans/v8/sRBNtc46w65uJE451UYmW87DCVO6wo6i5LKIyZDzK40.ttf",
+    "600": "http://fonts.gstatic.com/s/expletussans/v8/cl6rhMY77Ilk8lB_uYRRwCvj1tU7IJMS3CS9kCx2B3U.ttf",
+    "600italic": "http://fonts.gstatic.com/s/expletussans/v8/sRBNtc46w65uJE451UYmW8yKH23ZS6zCKOFHG0e_4JE.ttf",
+    "700": "http://fonts.gstatic.com/s/expletussans/v8/cl6rhMY77Ilk8lB_uYRRwFCbmAUID8LN-q3pJpOk3Ys.ttf",
+    "700italic": "http://fonts.gstatic.com/s/expletussans/v8/sRBNtc46w65uJE451UYmW5F66r9C4AnxxlBlGd7xY4g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell English SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfellenglishsc/v6/h3Tn6yWfw4b5qaLD1RWvz5ATixNthKRRR1XVH3rJNiw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Euphoria Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/euphoriascript/v4/c4XB4Iijj_NvSsCF4I0O2MxLhO8OSNnfAp53LK1_iRs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Suwannaphum",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/suwannaphum/v9/1jIPOyXied3T79GCnSlCN6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "UnifrakturMaguntia",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/unifrakturmaguntia/v7/7KWy3ymCVR_xfAvvcIXm3-kdNg30GQauG_DE-tMYtWk.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cambo",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cambo/v5/PnwpRuTdkYCf8qk4ajmNRA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kristi",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kristi/v7/aRsgBQrkQkMlu4UPSnJyOQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kite One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kiteone/v4/8ojWmgUc97m0f_i6sTqLoQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cantora One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cantoraone/v5/oI-DS62RbHI8ZREjp73ehqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Federo",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/federo/v8/JPhe1S2tujeyaR79gXBLeQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Engagement",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/engagement/v5/4Uz0Jii7oVPcaFRYmbpU6vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Mono",
+   "category": "monospace",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "greek",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novamono/v7/6-SChr5ZIaaasJFBkgrLNw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Uncial Antiqua",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/uncialantiqua/v4/F-leefDiFwQXsyd6eaSllqrFJ4O13IHVxZbM6yoslpo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Shojumaru",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/shojumaru/v4/WP8cxonzQQVAoI3RJQ2wug.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bowlby One SC",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bowlbyonesc/v8/8ZkeXftTuzKBtmxOYXoRedDkZCMxWJecxjvKm2f8MJw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Podkova",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/podkova/v8/eylljyGVfB8ZUQjYY3WZRQ.ttf",
+    "700": "http://fonts.gstatic.com/s/podkova/v8/SqW4aa8m_KVrOgYSydQ33vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Stardos Stencil",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/stardosstencil/v6/ygEOyTW9a6u4fi4OXEZeTFf2eT4jUldwg_9fgfY_tHc.ttf",
+    "700": "http://fonts.gstatic.com/s/stardosstencil/v6/h4ExtgvoXhPtv9Ieqd-XC81wDCbBgmIo8UyjIhmkeSM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Arizonia",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/arizonia/v6/yzJqkHZqryZBTM7RKYV9Wg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Stalemate",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/stalemate/v4/wQLCnG0qB6mOu2Wit2dt_w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Meddon",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/meddon/v9/f8zJO98uu2EtSj9p7ci9RA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Italiana",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/italiana/v4/dt95fkCSTOF-c6QNjwSycA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Griffy",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/griffy/v4/vWkyYGBSyE5xjnShNtJtzw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Herr Von Muellerhoff",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/herrvonmuellerhoff/v6/mmy24EUmk4tjm4gAEjUd7NLGIYrUsBdh-JWHYgiDiMU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Poller One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pollerone/v6/dkctmDlTPcZ6boC8662RA_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Numans",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/numans/v6/g5snI2p6OEjjTNmTHyBdiQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cambay",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cambay/v1/etU9Bab4VuhzS-OKsb1VXg.ttf",
+    "italic": "http://fonts.gstatic.com/s/cambay/v1/ZEz9yNqpEOgejaw1rBhugQ.ttf",
+    "700": "http://fonts.gstatic.com/s/cambay/v1/jw9niBxa04eEhnSwTWCEgw.ttf",
+    "700italic": "http://fonts.gstatic.com/s/cambay/v1/j-5v_uUr0NXTumWN0siOiaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Buenard",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/buenard/v7/NSpMPGKAUgrLrlstYVvIXQ.ttf",
+    "700": "http://fonts.gstatic.com/s/buenard/v7/yUlGE115dGr7O9w9FlP3UvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mate",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mate/v5/ooFviPcJ6hZP5bAE71Cawg.ttf",
+    "italic": "http://fonts.gstatic.com/s/mate/v5/5XwW6_cbisGvCX5qmNiqfA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Delius Swash Caps",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/deliusswashcaps/v8/uXyrEUnoWApxIOICunRq7yIrxb5zDVgU2N3VzXm7zq4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Yeseva One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/yesevaone/v9/eenQQxvpzSA80JmisGcgX_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ledger",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ledger/v4/G432jp-tahOfWHbCYkI0jw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Esteban",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/esteban/v4/ESyhLgqDDyK5JcFPp2svDw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Over the Rainbow",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/overtherainbow/v7/6gp-gkpI2kie2dHQQLM2jQBdxkZd83xOSx-PAQ2QmiI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Concert One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/concertone/v7/N5IWCIGhUNdPZn_efTxKN6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Biryani",
+   "category": "sans-serif",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-22",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/biryani/v1/Xx38YzyTFF8n6mRS1Yd88vesZW2xOQ-xsNqO47m55DA.ttf",
+    "300": "http://fonts.gstatic.com/s/biryani/v1/u-bneRbizmFMd0VQp5Ze6vesZW2xOQ-xsNqO47m55DA.ttf",
+    "regular": "http://fonts.gstatic.com/s/biryani/v1/W7bfR8-IY76Xz0QoB8L2xw.ttf",
+    "600": "http://fonts.gstatic.com/s/biryani/v1/1EdcPCVxBR2txgjrza6_YPesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/biryani/v1/qN2MTZ0j1sKSCtfXLB2dR_esZW2xOQ-xsNqO47m55DA.ttf",
+    "800": "http://fonts.gstatic.com/s/biryani/v1/DJyziS7FEy441v22InYdevesZW2xOQ-xsNqO47m55DA.ttf",
+    "900": "http://fonts.gstatic.com/s/biryani/v1/trcLkrIut0lM_PPSyQfAMPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sniglet",
+   "category": "display",
+   "variants": [
+    "regular",
+    "800"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sniglet/v7/XWhyQLHH4SpCVsHRPRgu9w.ttf",
+    "800": "http://fonts.gstatic.com/s/sniglet/v7/NLF91nBmcEfkBgcEWbHFa_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Karma",
+   "category": "serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/karma/v5/lH6ijJnguWR2Sz7tEl6MQQ.ttf",
+    "regular": "http://fonts.gstatic.com/s/karma/v5/wvqTxAGBUrTqU0urTEoPIw.ttf",
+    "500": "http://fonts.gstatic.com/s/karma/v5/9YGjxi6Hcvz2Kh-rzO_cAw.ttf",
+    "600": "http://fonts.gstatic.com/s/karma/v5/h_CVzXXtqSxjfS2sIwaejA.ttf",
+    "700": "http://fonts.gstatic.com/s/karma/v5/smuSM08oApsQPPVYbHd1CA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Geo",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/geo/v8/mJuJYk5Pww84B4uHAQ1XaA.ttf",
+    "italic": "http://fonts.gstatic.com/s/geo/v8/8_r1wToF7nPdDuX1qxel6Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mate SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/matesc/v5/-YkIT2TZoPZF6pawKzDpWw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Life Savers",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lifesavers/v6/g49cUDk4Y1P0G5NMkMAm7qCWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/lifesavers/v6/THQKqChyYUm97rNPVFdGGXe1Pd76Vl7zRpE7NLJQ7XU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Metamorphous",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/metamorphous/v6/wGqUKXRinIYggz-BTRU9ei3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gabriela",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gabriela/v4/B-2ZfbAO3HDrxqV6lR5tdA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Vibur",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/vibur/v7/xB9aKsUbJo68XP0bAg2iLw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mouse Memoirs",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mousememoirs/v4/NBFaaJFux_j0AQbAsW3QeH8f0n03UdmQgF_CLvNR2vg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Holtwood One SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/holtwoodonesc/v7/sToOq3cIxbfnhbEkgYNuBbAgSRh1LpJXlLfl8IbsmHg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dawning of a New Day",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dawningofanewday/v7/JiDsRhiKZt8uz3NJ5xA06gXLnohmOYWQZqo_sW8GLTk.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mr Dafoe",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mrdafoe/v5/s32Q1S6ZkT7EaX53mUirvQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Unna",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/unna/v8/UAS0AM7AmbdCNY_80xyAZQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sofia",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sofia/v5/Imnvx0Ag9r6iDBFUY5_RaQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ruslan Display",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ruslandisplay/v7/SREdhlyLNUfU1VssRBfs3rgH88D3l9N4auRNHrNS708.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Averia Sans Libre",
+   "category": "display",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/averiasanslibre/v4/_9-jTfQjaBsWAF_yp5z-V4CP_KG_g80s1KXiBtJHoNc.ttf",
+    "300italic": "http://fonts.gstatic.com/s/averiasanslibre/v4/o7BEIK-fG3Ykc5Rzteh88YuyGu4JqttndUh4gRKxic0.ttf",
+    "regular": "http://fonts.gstatic.com/s/averiasanslibre/v4/yRJpjT39KxACO9F31mj_LqV8_KRn4epKAjTFK1s1fsg.ttf",
+    "italic": "http://fonts.gstatic.com/s/averiasanslibre/v4/COEzR_NPBSUOl3pFwPbPoCZU2HnUZT1xVKaIrHDioao.ttf",
+    "700": "http://fonts.gstatic.com/s/averiasanslibre/v4/_9-jTfQjaBsWAF_yp5z-V8QwVOrz1y5GihpZmtKLhlI.ttf",
+    "700italic": "http://fonts.gstatic.com/s/averiasanslibre/v4/o7BEIK-fG3Ykc5Rzteh88bXy1DXgmJcVtKjM5UWamMs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Prociono",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/prociono/v6/43ZYDHWogdFeNBWTl6ksmw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell Double Pica",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfelldoublepica/v6/yN1wY_01BkQnO0LYAhXdUol14jEdVOhEmvtCMCVwYak.ttf",
+    "italic": "http://fonts.gstatic.com/s/imfelldoublepica/v6/64odUh2hAw8D9dkFKTlWYq0AWwkgdQfsRHec8TYi4mI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cutive Mono",
+   "category": "monospace",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cutivemono/v4/ncWQtFVKcSs8OW798v30k6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rationale",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rationale/v7/7M2eN-di0NGLQse7HzJRfg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Medula One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/medulaone/v6/AasPgDQak81dsTGQHc5zUPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dorsa",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dorsa/v7/wCc3cUe6XrmG2LQE6GlIrw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Margarine",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/margarine/v5/DJnJwIrcO_cGkjSzY3MERw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kavoon",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kavoon/v4/382m-6baKXqJFQjEgobt6Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell Great Primer",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfellgreatprimer/v6/AL8ALGNthei20f9Cu3e93rgeX3ROgtTz44CitKAxzKI.ttf",
+    "italic": "http://fonts.gstatic.com/s/imfellgreatprimer/v6/1a-artkXMVg682r7TTxVY1_YG2SFv8Ma7CxRl1S3o7g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Aladin",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/aladin/v5/PyuJ5cVHkduO0j5fAMKvAA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Flamenco",
+   "category": "display",
+   "variants": [
+    "300",
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/flamenco/v6/x9iI5CogvuZVCGoRHwXuo6CWcynf_cDxXwCLxiixG1c.ttf",
+    "regular": "http://fonts.gstatic.com/s/flamenco/v6/HC0ugfLLgt26I5_BWD1PZA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bilbo Swash Caps",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bilboswashcaps/v7/UB_-crLvhx-PwGKW1oosDmYeFSdnSpRYv5h9gpdlD1g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Codystar",
+   "category": "display",
+   "variants": [
+    "300",
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/codystar/v4/EVaUzfJkcb8Zqx9kzQLXqqCWcynf_cDxXwCLxiixG1c.ttf",
+    "regular": "http://fonts.gstatic.com/s/codystar/v4/EN-CPFKYowSI7SuR7-0cZA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Stint Ultra Expanded",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/stintultraexpanded/v4/FeigX-wDDgHMCKuhekhedQ7dxr0N5HY0cZKknTIL6n4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Krona One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kronaone/v4/zcQj4ljqTo166AdourlF9w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Coda Caption",
+   "category": "sans-serif",
+   "variants": [
+    "800"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-08-12",
+   "files": {
+    "800": "http://fonts.gstatic.com/s/codacaption/v9/YDl6urZh-DUFhiMBTgAnz_qsay_1ZmRGmC8pVRdIfAg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sancreek",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sancreek/v7/8ZacBMraWMvHly4IJI3esw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Vast Shadow",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/vastshadow/v6/io4hqKX3ibiqQQjYfW0-h6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Averia Serif Libre",
+   "category": "display",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/averiaseriflibre/v5/yvITAdr5D1nlsdFswJAb8SmC4gFJ2PHmfdVKEd_5S9M.ttf",
+    "300italic": "http://fonts.gstatic.com/s/averiaseriflibre/v5/YOLFXyye4sZt6AZk1QybCG2okl0bU63CauowU4iApig.ttf",
+    "regular": "http://fonts.gstatic.com/s/averiaseriflibre/v5/fdtF30xa_Erw0zAzOoG4BZqY66i8AUyI16fGqw0iAew.ttf",
+    "italic": "http://fonts.gstatic.com/s/averiaseriflibre/v5/o9qhvK9iT5iDWfyhQUe-6Ru_b0bTq5iipbJ9hhgHJ6U.ttf",
+    "700": "http://fonts.gstatic.com/s/averiaseriflibre/v5/yvITAdr5D1nlsdFswJAb8Q50KV5TaOVolur4zV2iZsg.ttf",
+    "700italic": "http://fonts.gstatic.com/s/averiaseriflibre/v5/YOLFXyye4sZt6AZk1QybCNxohRXP4tNDqG3X4Hqn21k.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Monofett",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/monofett/v6/C6K5L799Rgxzg2brgOaqAw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tulpen One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tulpenone/v6/lwcTfVIEVxpZLZlWzR5baPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chau Philomene One",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chauphilomeneone/v4/KKc5egCL-a2fFVoOA2x6tBFi5dxgSTdxqnMJgWkBJcg.ttf",
+    "italic": "http://fonts.gstatic.com/s/chauphilomeneone/v4/eJj1PY_iN4KiIuyOvtMHJP6uyLkxyiC4WcYA74sfquE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Maiden Orange",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/maidenorange/v6/ZhKIA2SPisEwdhW7g0RUWojjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cherry Swash",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cherryswash/v4/HqOk7C7J1TZ5i3L-ejF0vi3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/cherryswash/v4/-CfyMyQqfucZPQNB0nvYyED2ttfZwueP-QU272T9-k4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Scheherazade",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin",
+    "arabic"
+   ],
+   "version": "v11",
+   "lastModified": "2015-08-26",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/scheherazade/v11/AuKlqGWzUC-8XqMOmsqXiy3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/scheherazade/v11/C1wtT46acJkQxc6mPHwvHED2ttfZwueP-QU272T9-k4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Henny Penny",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/hennypenny/v4/XRgo3ogXyi3tpsFfjImRF6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Donegal One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/donegalone/v4/6kN4-fDxz7T9s5U61HwfF6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rye",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rye/v4/VUrJlpPpSZxspl3w_yNOrQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell DW Pica SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfelldwpicasc/v6/xBKKJV4z2KsrtQnmjGO17JZ9RBdEL0H9o5qzT1Rtof4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Junge",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/junge/v4/j4IXCXtxrw9qIBheercp3A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Amarante",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/amarante/v4/2dQHjIBWSpydit5zkJZnOw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Oldenburg",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/oldenburg/v4/dqA_M_uoCVXZbCO-oKBTnQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell French Canon",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfellfrenchcanon/v6/iKB0WL1BagSpNPz3NLMdsJ3V2FNpBrlLSvqUnERhBP8.ttf",
+    "italic": "http://fonts.gstatic.com/s/imfellfrenchcanon/v6/owCuNQkLLFW7TBBPJbMnhRa-QL94KdW80H29tcyld2A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fresca",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fresca/v5/2q7Qm9sCo1tWvVgSDVWNIw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Share Tech Mono",
+   "category": "monospace",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-07-22",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sharetechmono/v5/RQxK-3RA0Lnf3gnnnNrAscwD6PD0c3_abh9zHKQtbGU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Wallpoet",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/wallpoet/v8/hmum4WuBN4A0Z_7367NDIg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Snowburst One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/snowburstone/v4/zSQzKOPukXRux2oTqfYJjIjjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Martel",
+   "category": "serif",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-22",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/martel/v1/_wfGdswZbat7P4tupHLA1w.ttf",
+    "300": "http://fonts.gstatic.com/s/martel/v1/SghoV2F2VPdVU3P0a4fa9w.ttf",
+    "regular": "http://fonts.gstatic.com/s/martel/v1/9ALu5czkaaf5zsYk6GJEnQ.ttf",
+    "600": "http://fonts.gstatic.com/s/martel/v1/Kt9uPhH1PvUwuZ5Y6zuAMQ.ttf",
+    "700": "http://fonts.gstatic.com/s/martel/v1/4OzIiKB5wE36xXL2U0vzWQ.ttf",
+    "800": "http://fonts.gstatic.com/s/martel/v1/RVF8drcQoRkRL7l_ZkpTlQ.ttf",
+    "900": "http://fonts.gstatic.com/s/martel/v1/iS0YUpFJoiLRlnyl40rpEA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Poppins",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-03",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/poppins/v1/VIeViZ2fPtYBt3B2fQZplvesZW2xOQ-xsNqO47m55DA.ttf",
+    "regular": "http://fonts.gstatic.com/s/poppins/v1/hlvAxH6aIdOjWlLzgm0jqg.ttf",
+    "500": "http://fonts.gstatic.com/s/poppins/v1/4WGKlFyjcmCFVl8pRsgZ9vesZW2xOQ-xsNqO47m55DA.ttf",
+    "600": "http://fonts.gstatic.com/s/poppins/v1/-zOABrCWORC3lyDh-ajNnPesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/poppins/v1/8JitanEsk5aDh7mDYs-fYfesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rouge Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rougescript/v5/AgXDSqZJmy12qS0ixjs6Vy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Cagliostro",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/cagliostro/v5/i85oXbtdSatNEzss99bpj_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Delius Unicase",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/deliusunicase/v9/b2sKujV3Q48RV2PQ0k1vqu6rPKfVZo7L2bERcf0BDns.ttf",
+    "700": "http://fonts.gstatic.com/s/deliusunicase/v9/7FTMTITcb4dxUp99FAdTqNy5weKXdcrx-wE0cgECMq8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Balthazar",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/balthazar/v5/WgbaSIs6dJAGXJ0qbz2xlw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Overlock SC",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/overlocksc/v5/8D7HYDsvS_g1GhBnlHzgzaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Londrina Outline",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/londrinaoutline/v5/lls08GOa1eT74p072l1AWJmp8DTZ6iHear7UV05iykg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Condiment",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/condiment/v4/CstmdiPpgFSV0FUNL5LrJA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sunshiney",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sunshiney/v6/kaWOb4pGbwNijM7CkxK1sQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Artifika",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/artifika/v6/Ekfp4H4QG7D-WsABDOyj8g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Miltonian Tattoo",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/miltoniantattoo/v9/1oU_8OGYwW46eh02YHydn2uk0YtI6thZkz1Hmh-odwg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Romanesco",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/romanesco/v5/2udIjUrpK_CPzYSxRVzD4Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Raleway Dots",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ralewaydots/v4/lhLgmWCRcyz-QXo8LCzTfC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Inika",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/inika/v4/eZCrULQGaIxkrRoGz_DjhQ.ttf",
+    "700": "http://fonts.gstatic.com/s/inika/v4/bl3ZoTyrWsFun2zYbsgJrA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bilbo",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bilbo/v6/-ty-lPs5H7OIucWbnpFrkA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Galindo",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/galindo/v4/2lafAS_ZEfB33OJryhXDUg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "MedievalSharp",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/medievalsharp/v8/85X_PjV6tftJ0-rX7KYQkOe45sJkivqprK7VkUlzfg0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Round",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novaround/v8/7-cK3Ari_8XYYFgVMxVhDvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Redressed",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/redressed/v6/3aZ5sTBppH3oSm5SabegtA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Stint Ultra Condensed",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/stintultracondensed/v5/8DqLK6-YSClFZt3u3EgOUYelbRYnLTTQA1Z5cVLnsI4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nosifer",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/nosifer/v5/7eJGoIuHRrtcG00j6CptSA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rosarivo",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rosarivo/v4/EmPiINK0qyqc7KSsNjJamA.ttf",
+    "italic": "http://fonts.gstatic.com/s/rosarivo/v4/u3VuWsWQlX1pDqsbz4paNPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "McLaren",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mclaren/v4/OprvTGxaiINBKW_1_U0eoQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Habibi",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/habibi/v5/YYyqXF6pWpL7kmKgS_2iUA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ruluko",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ruluko/v4/lv4cMwJtrx_dzmlK5SDc1g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Stoke",
+   "category": "serif",
+   "variants": [
+    "300",
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/stoke/v6/Sell9475FOS8jUqQsfFsUQ.ttf",
+    "regular": "http://fonts.gstatic.com/s/stoke/v6/A7qJNoqOm2d6o1E6e0yUFg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell Great Primer SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfellgreatprimersc/v6/A313vRj97hMMGFjt6rgSJtRg-ciw1Y27JeXb2Zv4lZQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fondamento",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fondamento/v5/6LWXcjT1B7bnWluAOSNfMPesZW2xOQ-xsNqO47m55DA.ttf",
+    "italic": "http://fonts.gstatic.com/s/fondamento/v5/y6TmwhSbZ8rYq7OTFyo7OS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Milonga",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/milonga/v4/dzNdIUSTGFmy2ahovDRcWg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ramabhadra",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ramabhadra/v5/JyhxLXRVQChLDGADS_c5MPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Aguafina Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/aguafinascript/v5/65g7cgMtMGnNlNyq_Z6CvMxLhO8OSNnfAp53LK1_iRs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gurajada",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gurajada/v4/6Adfkl4PCRyq6XTENACEyA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Jacques Francois",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/jacquesfrancois/v4/_-0XWPQIW6tOzTHg4KaJ_M13D_4KM32Q4UmTSjpuNGQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell French Canon SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfellfrenchcanonsc/v6/kA3bS19-tQbeT_iG32EZmaiyyzHwYrAbmNulTz423iM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Pirata One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pirataone/v4/WnbD86B4vB2ckYcL7oxuhvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Miniver",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/miniver/v5/4yTQohOH_cWKRS5laRFhYg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Atomic Age",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/atomicage/v6/WvBMe4FxANIKpo6Oi0mVJ_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Keania One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/keaniaone/v4/PACrDKZWngXzgo-ucl6buvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Swanky and Moo Moo",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/swankyandmoomoo/v6/orVNZ9kDeE3lWp3U3YELu9DVLKqNC3_XMNHhr8S94FU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Buda",
+   "category": "display",
+   "variants": [
+    "300"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/buda/v6/hLtAmNUmEMJH2yx7NGUjnA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Quintessential",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/quintessential/v4/mmk6ioesnTrEky_Zb92E5s02lXbtMOtZWfuxKeMZO8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "UnifrakturCook",
+   "category": "display",
+   "variants": [
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "700": "http://fonts.gstatic.com/s/unifrakturcook/v8/ASwh69ykD8iaoYijVEU6RrWZkcsCTHKV51zmcUsafQ0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Text Me One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/textmeone/v4/9em_3ckd_P5PQkP4aDyDLqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Battambang",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/battambang/v9/MzrUfQLefYum5vVGM3EZVPesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/battambang/v9/dezbRtMzfzAA99DmrCYRMgJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sonsie One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sonsieone/v5/KSP7xT1OSy0q2ob6RQOTWPesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Port Lligat Sans",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/portlligatsans/v5/CUEdhRk7oC7up0p6t0g4P6mASEpx5X0ZpsuJOuvfOGA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sail",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sail/v6/iuEoG6kt-bePGvtdpL0GUQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Snippet",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/snippet/v6/eUcYMLq2GtHZovLlQH_9kA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "League Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/leaguescript/v7/wnRFLvfabWK_DauqppD6vSeUSrabuTpOsMEiRLtKwk0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Averia Libre",
+   "category": "display",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/averialibre/v4/r6hGL8sSLm4dTzOPXgx5XacQoVhARpoaILP7amxE_8g.ttf",
+    "300italic": "http://fonts.gstatic.com/s/averialibre/v4/I6wAYuAvOgT7el2ePj2nkina0FLWfcB-J_SAYmcAXaI.ttf",
+    "regular": "http://fonts.gstatic.com/s/averialibre/v4/rYVgHZZQICWnhjguGsBspC3USBnSvpkopQaUR-2r7iU.ttf",
+    "italic": "http://fonts.gstatic.com/s/averialibre/v4/1etzuoNxVHR8F533EkD1WfMZXuCXbOrAvx5R0IT5Oyo.ttf",
+    "700": "http://fonts.gstatic.com/s/averialibre/v4/r6hGL8sSLm4dTzOPXgx5XUD2ttfZwueP-QU272T9-k4.ttf",
+    "700italic": "http://fonts.gstatic.com/s/averialibre/v4/I6wAYuAvOgT7el2ePj2nkvAs9-1nE9qOqhChW0m4nDE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bigshot One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bigshotone/v6/wSyZjBNTWDQHnvWE2jt6j6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fira Mono",
+   "category": "monospace",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin-ext",
+    "greek",
+    "latin",
+    "cyrillic-ext",
+    "cyrillic"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/firamono/v3/WQOm1D4RO-yvA9q9trJc8g.ttf",
+    "700": "http://fonts.gstatic.com/s/firamono/v3/l24Wph3FsyKAbJ8dfExTZy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dynalight",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dynalight/v5/-CWsIe8OUDWTIHjSAh41kA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Angkor",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/angkor/v8/DLpLgIS-8F10ecwKqCm95Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Linden Hill",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lindenhill/v6/UgsC0txqd-E1yjvjutwm_KCWcynf_cDxXwCLxiixG1c.ttf",
+    "italic": "http://fonts.gstatic.com/s/lindenhill/v6/OcS3bZcu8vJvIDH8Zic83keOrDcLawS7-ssYqLr2Xp4.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Spirax",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/spirax/v5/IOKqhk-Ccl7y31yDsePPkw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Alike Angular",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/alikeangular/v6/OpeCu4xxI3qO1C7CZcJtPT3XH2uEnVI__ynTBvNyki8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Slim",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novaslim/v8/rPYXC81_VL2EW-4CzBX65g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mandali",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mandali/v4/0lF8yJ7fkyjXuqtSi5bWbQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Julee",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/julee/v6/CAib-jsUsSO8SvVRnE9fHA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "IM Fell Double Pica SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/imfelldoublepicasc/v6/jkrUtrLFpMw4ZazhfkKsGwc4LoC4OJUqLw9omnT3VOU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Autour One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/autourone/v4/2xmQBcg7FN72jaQRFZPIDvesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Offside",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/offside/v4/v0C913SB8wqQUvcu1faUqw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Asul",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/asul/v5/9qpsNR_OOwyOYyo2N0IbBw.ttf",
+    "700": "http://fonts.gstatic.com/s/asul/v5/uO8uNmxaq87-DdPmkEg5Gg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Iceberg",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/iceberg/v4/p2XVm4M-N0AOEEOymFKC5w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sarina",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sarina/v5/XYtRfaSknHIU3NHdfTdXoQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bokor",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bokor/v8/uAKdo0A85WW23Gs6mcbw7A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Butcherman",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/butcherman/v7/bxiJmD567sPBVpJsT0XR0vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rum Raisin",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rumraisin/v4/kDiL-ntDOEq26B7kYM7cx_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Antic Didone",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/anticdidone/v4/r3nJcTDuOluOL6LGDV1vRy3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Glass Antiqua",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/glassantiqua/v4/0yLrXKplgdUDIMz5TnCHNODcg5akpSnIcsPhLOFv7l8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mrs Saint Delafield",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mrssaintdelafield/v4/vuWagfFT7bj9lFtZOFBwmjHMBelqWf3tJeGyts2SmKU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Della Respira",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dellarespira/v4/F4E6Lo_IZ6L9AJCcbqtDVeDcg5akpSnIcsPhLOFv7l8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "GFS Neohellenic",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "greek"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gfsneohellenic/v7/B4xRqbn-tANVqVgamMsSDiayCZa0z7CpFzlkqoCHztc.ttf",
+    "italic": "http://fonts.gstatic.com/s/gfsneohellenic/v7/KnaWrO4awITAqigQIIYXKkCTdomiyJpIzPbEbIES3rU.ttf",
+    "700": "http://fonts.gstatic.com/s/gfsneohellenic/v7/7HwjPQa7qNiOsnUce2h4448_BwCLZY3eDSV6kppAwI8.ttf",
+    "700italic": "http://fonts.gstatic.com/s/gfsneohellenic/v7/FwWjoX6XqT-szJFyqsu_GYFF0fM4h-krcpQk7emtCpE.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Palanquin",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-22",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/palanquin/v1/Hu0eGDVGK_g4saUFu6AK3KCWcynf_cDxXwCLxiixG1c.ttf",
+    "200": "http://fonts.gstatic.com/s/palanquin/v1/pqXYXD7-VI5ezTjeqQOcyC3USBnSvpkopQaUR-2r7iU.ttf",
+    "300": "http://fonts.gstatic.com/s/palanquin/v1/c0-J5OCAagpFCKkKraz-Ey3USBnSvpkopQaUR-2r7iU.ttf",
+    "regular": "http://fonts.gstatic.com/s/palanquin/v1/xCwBUoAEV0kzCDwerAZ0Aw.ttf",
+    "500": "http://fonts.gstatic.com/s/palanquin/v1/wLvvkEcZMKy95afLWh2EfC3USBnSvpkopQaUR-2r7iU.ttf",
+    "600": "http://fonts.gstatic.com/s/palanquin/v1/405UIAv95_yZkCECrH6y-i3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/palanquin/v1/-UtkePo3NFvxEN3rGCtTvi3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Irish Grover",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/irishgrover/v6/kUp7uUPooL-KsLGzeVJbBC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Trykker",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/trykker/v5/YiVrVJpBFN7I1l_CWk6yYQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kurale",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v1",
+   "lastModified": "2015-05-14",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kurale/v1/rxeyIcvQlT4XAWwNbXFCfw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Wendy One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/wendyone/v4/R8CJT2oDXdMk_ZtuHTxoxw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Piedra",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/piedra/v5/owf-AvEEyAj9LJ2tVZ_3Mw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rubik",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "300italic",
+    "regular",
+    "italic",
+    "500",
+    "500italic",
+    "700",
+    "700italic",
+    "900",
+    "900italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v1",
+   "lastModified": "2015-07-22",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/rubik/v1/o1vXYO8YwDpErHEAPAxpOg.ttf",
+    "300italic": "http://fonts.gstatic.com/s/rubik/v1/NyXDvUhvZLSWiVfGa5KM-vesZW2xOQ-xsNqO47m55DA.ttf",
+    "regular": "http://fonts.gstatic.com/s/rubik/v1/4sMyW_teKWHB3K8Hm-Il6A.ttf",
+    "italic": "http://fonts.gstatic.com/s/rubik/v1/elD65ddI0qvNcCh42b1Iqg.ttf",
+    "500": "http://fonts.gstatic.com/s/rubik/v1/D4HihERG27s-BJrQ4dvkbw.ttf",
+    "500italic": "http://fonts.gstatic.com/s/rubik/v1/0hcxMdoMbXtHiEM1ebdN6PesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/rubik/v1/m1GGHcpLe6Mb0_sAyjXE4g.ttf",
+    "700italic": "http://fonts.gstatic.com/s/rubik/v1/R4g_rs714cUXVZcdnRdHw_esZW2xOQ-xsNqO47m55DA.ttf",
+    "900": "http://fonts.gstatic.com/s/rubik/v1/mOHfPRl5uP4vw7-5-dbnng.ttf",
+    "900italic": "http://fonts.gstatic.com/s/rubik/v1/HH1b7kBbwInqlw8OQxRE5vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rammetto One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rammettoone/v5/mh0uQ1tV8QgSx9v_KyEYPC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kenia",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kenia/v8/OLM9-XfITK9PsTLKbGBrwg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Wellfleet",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/wellfleet/v4/J5tOx72iFRPgHYpbK9J4XQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sarpanch",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sarpanch/v1/YMBZdT27b6O5a1DADbAGSg.ttf",
+    "500": "http://fonts.gstatic.com/s/sarpanch/v1/Ov7BxSrFSZYrfuJxL1LzQaCWcynf_cDxXwCLxiixG1c.ttf",
+    "600": "http://fonts.gstatic.com/s/sarpanch/v1/WTnP2wnc0qSbUaaDG-2OQ6CWcynf_cDxXwCLxiixG1c.ttf",
+    "700": "http://fonts.gstatic.com/s/sarpanch/v1/57kYsSpovYmFaEt2hsZhv6CWcynf_cDxXwCLxiixG1c.ttf",
+    "800": "http://fonts.gstatic.com/s/sarpanch/v1/OKyqPLjdnuVghR-1TV6RzaCWcynf_cDxXwCLxiixG1c.ttf",
+    "900": "http://fonts.gstatic.com/s/sarpanch/v1/JhYc2cr6kqWTo_P0vfvJR6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Astloch",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/astloch/v6/fmbitVmHYLQP7MGPuFgpag.ttf",
+    "700": "http://fonts.gstatic.com/s/astloch/v6/aPkhM2tL-tz1jX6aX2rvo_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ruthie",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ruthie/v6/vJ2LorukHSbWYoEs5juivg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Trochut",
+   "category": "display",
+   "variants": [
+    "regular",
+    "italic",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/trochut/v4/6Y65B0x-2JsnYt16OH5omw.ttf",
+    "italic": "http://fonts.gstatic.com/s/trochut/v4/pczUwr4ZFvC79TgNO5cZng.ttf",
+    "700": "http://fonts.gstatic.com/s/trochut/v4/lWqNOv6ISR8ehNzGLFLnJ_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "New Rocker",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/newrocker/v5/EFUWzHJedEkpW399zYOHofesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lovers Quarrel",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/loversquarrel/v4/gipdZ8b7pKb89MzQLAtJHLHLxci2ElvNEmOB303HLk0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sofadi One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sofadione/v4/nirf4G12IcJ6KI8Eoj119fesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Warnes",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/warnes/v6/MXG7_Phj4YpzAXxKGItuBw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ribeye Marrow",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ribeyemarrow/v6/q7cBSA-4ErAXBCDFPrhlY0cTNmV93fYG7UKgsLQNQWs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chango",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chango/v5/3W3AeMMtRTH08t5qLOjBmg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Passero One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/passeroone/v8/Yc-7nH5deCCv9Ed0MMnAQqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Joti One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/jotione/v4/P3r_Th0ESHJdzunsvWgUfQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Modern Antiqua",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/modernantiqua/v6/8qX_tr6Xzy4t9fvZDXPkh6rFJ4O13IHVxZbM6yoslpo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nokora",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/nokora/v9/dRyz1JfnyKPNaRcBNX9F9A.ttf",
+    "700": "http://fonts.gstatic.com/s/nokora/v9/QMqqa4QEOhQpiig3cAPmbQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Montserrat Subrayada",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/montserratsubrayada/v4/nzoCWCz0e9c7Mr2Gl8bbgrJymm6ilkk9f0nDA_sC_qk.ttf",
+    "700": "http://fonts.gstatic.com/s/montserratsubrayada/v4/wf-IKpsHcfm0C9uaz9IeGJvEcF1LWArDbGWgKZSH9go.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Flat",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novaflat/v8/pK7a0CoGzI684qe_XSHBqQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ribeye",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ribeye/v5/e5w3VE8HnWBln4Ll6lUj3Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Elsie",
+   "category": "display",
+   "variants": [
+    "regular",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/elsie/v5/gwspePauE45BJu6Ok1QrfQ.ttf",
+    "900": "http://fonts.gstatic.com/s/elsie/v5/1t-9f0N2NFYwAgN7oaISqg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Peralta",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/peralta/v4/cTJX5KEuc0GKRU9NXSm-8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Smythe",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/smythe/v7/yACD1gy_MpbB9Ft42fUvYw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Germania One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/germaniaone/v4/3_6AyUql_-FbDi1e68jHdC3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Spicy Rice",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/spicyrice/v5/WGCtz7cLoggXARPi9OGD6_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Galdeano",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/galdeano/v6/ZKFMQI6HxEG1jOT0UGSZUg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Combo",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/combo/v5/Nab98KjR3JZSSPGtzLyXNw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Petrona",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/petrona/v5/nnQwxlP6dhrGovYEFtemTg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ranchers",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ranchers/v4/9ya8CZYhqT66VERfjQ7eLA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Elsie Swash Caps",
+   "category": "display",
+   "variants": [
+    "regular",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/elsieswashcaps/v4/9L3hIJMPCf6sxCltnxd6X2YeFSdnSpRYv5h9gpdlD1g.ttf",
+    "900": "http://fonts.gstatic.com/s/elsieswashcaps/v4/iZnus9qif0tR5pGaDv5zdKoKBWBozTtxi30NfZDOXXU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Molle",
+   "category": "handwriting",
+   "variants": [
+    "italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "italic": "http://fonts.gstatic.com/s/molle/v4/9XTdCsjPXifLqo5et-YoGA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lancelot",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lancelot/v6/XMT7T_oo_MQUGAnU2v-sdA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Vampiro One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/vampiroone/v6/OVDs4gY4WpS5u3Qd1gXRW6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Montaga",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/montaga/v4/PwTwUboiD-M4-mFjZfJs2A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Jolly Lodger",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/jollylodger/v4/RX8HnkBgaEKQSHQyP9itiS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Geostar Fill",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/geostarfill/v6/Y5ovXPPOHYTfQzK2aM-hui3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Palanquin Dark",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-22",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/palanquindark/v1/PamTqrrgbBh_M3702w39rOfChn3JSg5yz_Q_xmrKQN0.ttf",
+    "500": "http://fonts.gstatic.com/s/palanquindark/v1/iXyBGf5UbFUu6BG8hOY-maMZTo-EwKMRQt3RWHocLi0.ttf",
+    "600": "http://fonts.gstatic.com/s/palanquindark/v1/iXyBGf5UbFUu6BG8hOY-mVNxaunw8i4Gywrk2SigRnk.ttf",
+    "700": "http://fonts.gstatic.com/s/palanquindark/v1/iXyBGf5UbFUu6BG8hOY-mWToair6W0TEE44XrlfKbiM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dangrek",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dangrek/v8/LOaFhBT-EHNxZjV8DAW_ew.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Akronim",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/akronim/v5/qA0L2CSArk3tuOWE1AR1DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Monsieur La Doulaise",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/monsieurladoulaise/v5/IMAdMj6Eq9jZ46CPctFtMKP61oAqTJXlx5ZVOBmcPdM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Odor Mean Chey",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/odormeanchey/v8/GK3E7EjPoBkeZhYshGFo0eVKG8sq4NyGgdteJLvqLDs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bubbler One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bubblerone/v4/e8S0qevkZAFaBybtt_SU4qCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Almendra",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "italic",
+    "700",
+    "700italic"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/almendra/v8/PDpbB-ZF7deXAAEYPkQOeg.ttf",
+    "italic": "http://fonts.gstatic.com/s/almendra/v8/CNWLyiDucqVKVgr4EMidi_esZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/almendra/v8/ZpLdQMj7Q2AFio4nNO6A76CWcynf_cDxXwCLxiixG1c.ttf",
+    "700italic": "http://fonts.gstatic.com/s/almendra/v8/-tXHKMcnn6FqrhJV3l1e3QJKKGfqHaYFsRG-T3ceEVo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Miltonian",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/miltonian/v8/Z4HrYZyqm0BnNNzcCUfzoQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Eagle Lake",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/eaglelake/v4/ZKlYin7caemhx9eSg6RvPfesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Yantramanav",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "300",
+    "regular",
+    "500",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-03",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/yantramanav/v1/Rs1I2PF4Z8GAb6qjgvr8wIAWxXGWZ3yJw6KhWS7MxOk.ttf",
+    "300": "http://fonts.gstatic.com/s/yantramanav/v1/HSfbC4Z8I8BZ00wiXeA5bC9-WlPSxbfiI49GsXo3q0g.ttf",
+    "regular": "http://fonts.gstatic.com/s/yantramanav/v1/FwdziO-qWAO8pZg8e376kaCWcynf_cDxXwCLxiixG1c.ttf",
+    "500": "http://fonts.gstatic.com/s/yantramanav/v1/HSfbC4Z8I8BZ00wiXeA5bMCNfqCYlB_eIx7H1TVXe60.ttf",
+    "700": "http://fonts.gstatic.com/s/yantramanav/v1/HSfbC4Z8I8BZ00wiXeA5bHe1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "900": "http://fonts.gstatic.com/s/yantramanav/v1/HSfbC4Z8I8BZ00wiXeA5bCenaqEuufTBk9XMKnKmgDA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Original Surfer",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/originalsurfer/v5/gdHw6HpSIN4D6Xt7pi1-qIkEz33TDwAZczo_6fY7eg0.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Asset",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/asset/v6/hfPmqY-JzuR1lULlQf9iTg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Siemreap",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/siemreap/v9/JSK-mOIsXwxo-zE9XDDl_g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Erica One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ericaone/v6/cIBnH2VAqQMIGYAcE4ufvQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Risque",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/risque/v4/92RnElGnl8yHP97-KV3Fyg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Goblin One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/goblinone/v6/331XtzoXgpVEvNTVcBJ_C_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Jacques Francois Shadow",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/jacquesfrancoisshadow/v4/V14y0H3vq56fY9SV4OL_FASt0D_oLVawA8L8b9iKjbs.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Cut",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novacut/v8/6q12jWcBvj0KO2cMRP97tA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Smokum",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/smokum/v6/8YP4BuAcy97X8WfdKfxVRw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Devonshire",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/devonshire/v5/I3ct_2t12SYizP8ZC-KFi_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Faster One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fasterone/v5/YxTOW2sf56uxD1T7byP5K_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Croissant One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/croissantone/v4/mPjsOObnC77fp1cvZlOfIYjjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Script",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novascript/v8/dEvxQDLgx1M1TKY-NmBWYaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kdam Thmor",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kdamthmor/v3/otCdP6UU-VBIrBfVDWBQJ_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Emilys Candy",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/emilyscandy/v4/PofLVm6v1SwZGOzC8s-I3S3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Emblema One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/emblemaone/v5/7IlBUjBWPIiw7cr_O2IfSaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Nova Oval",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/novaoval/v8/VuukVpKP8BwUf8o9W5LYQQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Koulen",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v10",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/koulen/v10/AAYOK8RSRO7FTskTzFuzNw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chicle",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chicle/v5/xg4q57Ut9ZmyFwLp51JLgg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Miss Fajardose",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/missfajardose/v6/WcXjlQPKn6nBfr8LY3ktNu6rPKfVZo7L2bERcf0BDns.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gorditas",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gorditas/v4/uMgZhXUyH6qNGF3QsjQT5Q.ttf",
+    "700": "http://fonts.gstatic.com/s/gorditas/v4/6-XCeknmxaon8AUqVkMnHaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Diplomata",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-03-20",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/diplomata/v6/u-ByBiKgN6rTMA36H3kcKg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Aubrey",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/aubrey/v8/zo9w8klO8bmOQIMajQ2aTA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bonbon",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bonbon/v7/IW3u1yzG1knyW5oz0s9_6Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Martel Sans",
+   "category": "sans-serif",
+   "variants": [
+    "200",
+    "300",
+    "regular",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-07",
+   "files": {
+    "200": "http://fonts.gstatic.com/s/martelsans/v1/7ajme85aKKx_SCWF59ImQEnzyIngrzGjGh22wPb6cGM.ttf",
+    "300": "http://fonts.gstatic.com/s/martelsans/v1/7ajme85aKKx_SCWF59ImQC9-WlPSxbfiI49GsXo3q0g.ttf",
+    "regular": "http://fonts.gstatic.com/s/martelsans/v1/91c8DPDZncMc0RFfhmc2RqCWcynf_cDxXwCLxiixG1c.ttf",
+    "600": "http://fonts.gstatic.com/s/martelsans/v1/7ajme85aKKx_SCWF59ImQJZ7xm-Bj30Bj2KNdXDzSZg.ttf",
+    "700": "http://fonts.gstatic.com/s/martelsans/v1/7ajme85aKKx_SCWF59ImQHe1Pd76Vl7zRpE7NLJQ7XU.ttf",
+    "800": "http://fonts.gstatic.com/s/martelsans/v1/7ajme85aKKx_SCWF59ImQA89PwPrYLaRFJ-HNCU9NbA.ttf",
+    "900": "http://fonts.gstatic.com/s/martelsans/v1/7ajme85aKKx_SCWF59ImQCenaqEuufTBk9XMKnKmgDA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Diplomata SC",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/diplomatasc/v5/JdVwAwfE1a_pahXjk5qpNi3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Metal Mania",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/metalmania/v6/isriV_rAUgj6bPWPN6l9QKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Moulpali",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/moulpali/v9/diD74BprGhmVkJoerKmrKA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Butterfly Kids",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/butterflykids/v4/J4NTF5M25htqeTffYImtlUZaDk62iwTBnbnvwSjZciA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Moul",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/moul/v8/Kb0ALQnfyXawP1a_P_gpTQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Purple Purse",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/purplepurse/v5/Q5heFUrdmei9axbMITxxxS3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Federant",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/federant/v7/tddZFSiGvxICNOGra0i5aA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Seymour One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/seymourone/v4/HrdG2AEG_870Xb7xBVv6C6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Revalia",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/revalia/v4/1TKw66fF5_poiL0Ktgo4_A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mrs Sheppards",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mrssheppards/v5/2WFsWMV3VUeCz6UVH7UjCn8f0n03UdmQgF_CLvNR2vg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Geostar",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/geostar/v6/A8WQbhQbpYx3GWWaShJ9GA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Freehand",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/freehand/v8/uEBQxvA0lnn_BrD6krlxMw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Londrina Sketch",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/londrinasketch/v4/p7Ai06aT1Ycp_D2fyE3z69d6z_uhFGnpCOifUY1fJQo.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Felipa",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/felipa/v4/SeyfyFZY7abAQXGrOIYnYg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Supermercado One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/supermercadoone/v6/kMGPVTNFiFEp1U274uBMb4mm5hmSKNFf3C5YoMa-lrM.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Plaster",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/plaster/v7/O4QG9Z5116CXyfJdR9zxLw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kantumruy",
+   "category": "sans-serif",
+   "variants": [
+    "300",
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-03",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/kantumruy/v3/ERRwQE0WG5uanaZWmOFXNi3USBnSvpkopQaUR-2r7iU.ttf",
+    "regular": "http://fonts.gstatic.com/s/kantumruy/v3/kQfXNYElQxr5dS8FyjD39Q.ttf",
+    "700": "http://fonts.gstatic.com/s/kantumruy/v3/gie_zErpGf_rNzs920C2Ji3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Londrina Shadow",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/londrinashadow/v4/dNYuzPS_7eYgXFJBzMoKdbw6Z3rVA5KDSi7aQxS92Nk.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Eater",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/eater/v5/gm6f3OmYEdbs3lPQtUfBkA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Underdog",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/underdog/v5/gBv9yjez_-5PnTprHWq0ig.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Laila",
+   "category": "serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-01",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/laila/v1/bLbIVEZF3IWSZ-in72GJvA.ttf",
+    "regular": "http://fonts.gstatic.com/s/laila/v1/6iYor3edprH7360qtBGoag.ttf",
+    "500": "http://fonts.gstatic.com/s/laila/v1/tkf8VtFvW9g3VsxQCA6WOQ.ttf",
+    "600": "http://fonts.gstatic.com/s/laila/v1/3EMP2L6JRQ4GaHIxCldCeA.ttf",
+    "700": "http://fonts.gstatic.com/s/laila/v1/R7P4z1xjcjecmjZ9GyhqHQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Preahvihear",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/preahvihear/v8/82tDI-xTc53CxxOzEG4hDaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Marko One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/markoone/v6/hpP7j861sOAco43iDc4n4w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Meie Script",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/meiescript/v4/oTIWE5MmPye-rCyVp_6KEqCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ewert",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ewert/v4/Em8hrzuzSbfHcTVqMjbAQg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Macondo Swash Caps",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/macondoswashcaps/v4/SsSR706z-MlvEH7_LS6JAPkkgYRHs6GSG949m-K6x2k.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Princess Sofia",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/princesssofia/v4/8g5l8r9BM0t1QsXLTajDe-wjmA7ie-lFcByzHGRhCIg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Arbutus",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/arbutus/v5/Go_hurxoUsn5MnqNVQgodQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sirin Stencil",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sirinstencil/v5/pRpLdo0SawzO7MoBpvowsImg74kgS1F7KeR8rWhYwkU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Suranna",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/suranna/v4/PYmfr6TQeTqZ-r8HnPM-kA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sevillana",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sevillana/v4/6m1Nh35oP7YEt00U80Smiw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Catamaran",
+   "category": "sans-serif",
+   "variants": [
+    "100",
+    "200",
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "latin-ext",
+    "tamil",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-08-06",
+   "files": {
+    "100": "http://fonts.gstatic.com/s/catamaran/v1/ilWHBiy0krUPdlmYxDuqC6CWcynf_cDxXwCLxiixG1c.ttf",
+    "200": "http://fonts.gstatic.com/s/catamaran/v1/hFc-HKSsGk6M-psujei1MC3USBnSvpkopQaUR-2r7iU.ttf",
+    "300": "http://fonts.gstatic.com/s/catamaran/v1/Aaag4ccR7Oh_4eai-jbrYC3USBnSvpkopQaUR-2r7iU.ttf",
+    "regular": "http://fonts.gstatic.com/s/catamaran/v1/MdNkM-DU8f6R-25Nxpr_XA.ttf",
+    "500": "http://fonts.gstatic.com/s/catamaran/v1/83WSX3F86qsvj1Z4EI0tQi3USBnSvpkopQaUR-2r7iU.ttf",
+    "600": "http://fonts.gstatic.com/s/catamaran/v1/a9PlHHnuBWiGGk0TwuFKTi3USBnSvpkopQaUR-2r7iU.ttf",
+    "700": "http://fonts.gstatic.com/s/catamaran/v1/PpgVtUHUdnBZYNpnzGbScy3USBnSvpkopQaUR-2r7iU.ttf",
+    "800": "http://fonts.gstatic.com/s/catamaran/v1/6VjB_uSfn3DZ93IQv58CmC3USBnSvpkopQaUR-2r7iU.ttf",
+    "900": "http://fonts.gstatic.com/s/catamaran/v1/5ys9TqpQc9Q6gHqbSox6py3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fascinate",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fascinate/v5/ZE0637WWkBPKt1AmFaqD3Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chonburi",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "thai",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-08-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chonburi/v1/jd9PfbW0x_8Myt_XeUxvSQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bigelow Rules",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bigelowrules/v4/FEJCPLwo07FS-6SK6Al50X8f0n03UdmQgF_CLvNR2vg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Vesper Libre",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "500",
+    "700",
+    "900"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-06-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/vesperlibre/v7/Cg-TeZFsqV8BaOcoVwzu2C3USBnSvpkopQaUR-2r7iU.ttf",
+    "500": "http://fonts.gstatic.com/s/vesperlibre/v7/0liLgNkygqH6EOtsVjZDsZMQuUSAwdHsY8ov_6tk1oA.ttf",
+    "700": "http://fonts.gstatic.com/s/vesperlibre/v7/0liLgNkygqH6EOtsVjZDsUD2ttfZwueP-QU272T9-k4.ttf",
+    "900": "http://fonts.gstatic.com/s/vesperlibre/v7/0liLgNkygqH6EOtsVjZDsaObDOjC3UL77puoeHsE3fw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Metal",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/metal/v9/zA3UOP13ooQcxjv04BZX5g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ramaraja",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ramaraja/v1/XIqzxFapVczstBedHdQTiw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dr Sugiyama",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/drsugiyama/v5/S5Yx3MIckgoyHhhS4C9Tv6CWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Almendra SC",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/almendrasc/v6/IuiLd8Fm9I6raSalxMoWeaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Flavors",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/flavors/v5/SPJi5QclATvon8ExcKGRvQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Stalinist One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v7",
+   "lastModified": "2015-07-23",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/stalinistone/v7/MQpS-WezM9W4Dd7D3B7I-UT7eZ8.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rozha One",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v2",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rozhaone/v2/PyrMHQ6lucEIxwKmhqsX8A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Mr Bedfort",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/mrbedfort/v5/81bGgHTRikLs_puEGshl7_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Content",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/content/v8/l8qaLjygvOkDEU2G6-cjfQ.ttf",
+    "700": "http://fonts.gstatic.com/s/content/v8/7PivP8Zvs2qn6F6aNbSQe_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chela One",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chelaone/v4/h5O0dEnpnIq6jQnWxZybrA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Jim Nightshade",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/jimnightshade/v4/_n43lYHXVWNgXegdYRIK9CF1W_bo0EdycfH0kHciIic.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Taprom",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/taprom/v8/-KByU3BaUsyIvQs79qFObg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Macondo",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/macondo/v5/G6yPNUscRPQ8ufBXs_8yRQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Jaldi",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v2",
+   "lastModified": "2015-06-10",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/jaldi/v2/x1vR-bPW9a1EB-BUVqttCw.ttf",
+    "700": "http://fonts.gstatic.com/s/jaldi/v2/OIbtgjjEp3aVWtjF6WY8mA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ruge Boogie",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rugeboogie/v7/U-TTmltL8aENLVIqYbI5QaCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Itim",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "thai",
+    "vietnamese",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-08-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/itim/v1/HHV9WK2x5lUkc5bxMXG8Tw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Kadwa",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-17",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/kadwa/v1/VwEN8oKGqaa0ug9kRpvSSg.ttf",
+    "700": "http://fonts.gstatic.com/s/kadwa/v1/NFPZaBfekj_Io-7vUMz4Ww.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "NTR",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ntr/v4/e7H4ZLtGfVOYyOupo6T12g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ranga",
+   "category": "display",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/ranga/v1/xpW6zFTNzY1JykoBIqE1Zg.ttf",
+    "700": "http://fonts.gstatic.com/s/ranga/v1/h8G_gEUH7vHKH-NkjAs34A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Bayon",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v8",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/bayon/v8/yTubusjTnpNRZwA4_50iVw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dekko",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v2",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dekko/v2/AKtgABKC1rUxgIgS-bpojw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Amita",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/amita/v1/RhdhGBXSJqkHo6g7miTEcQ.ttf",
+    "700": "http://fonts.gstatic.com/s/amita/v1/cIYA2Lzp7l2pcGsqpUidBg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Chenla",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v9",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/chenla/v9/aLNpdAUDq2MZbWz2U1a16g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Almendra Display",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/almendradisplay/v6/2Zuu97WJ_ez-87yz5Ai8fF6uyC_qD11hrFQ6EGgTJWI.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rubik Mono One",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin",
+    "cyrillic"
+   ],
+   "version": "v5",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rubikmonoone/v5/e_cupPtD4BrZzotubJD7UbAREgn5xbW23GEXXnhMQ5Y.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Hanalei",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/hanalei/v6/Sx8vVMBnXSQyK6Cn0CBJ3A.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Pragati Narrow",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v2",
+   "lastModified": "2015-06-10",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/pragatinarrow/v2/HzG2TfC862qPNsZsV_djPpTvAuddT2xDMbdz0mdLyZY.ttf",
+    "700": "http://fonts.gstatic.com/s/pragatinarrow/v2/DnSI1zRkc0CY-hI5SC3q3MLtdzs3iyjn_YuT226ZsLU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sumana",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-05-04",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sumana/v1/wgdl__wAK7pzliiWs0Nlog.ttf",
+    "700": "http://fonts.gstatic.com/s/sumana/v1/8AcM-KAproitONSBBHj3sQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fascinate Inline",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fascinateinline/v6/lRguYfMfWArflkm5aOQ5QJmp8DTZ6iHear7UV05iykg.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tenali Ramakrishna",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tenaliramakrishna/v3/M0nTmDqv2M7AGoGh-c946BZak5pSBHqWX6uyVMiMFoA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Gidugu",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/gidugu/v3/Ey6Eq3hrT6MM58iFItFcgw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sree Krushnadevaraya",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sreekrushnadevaraya/v4/CdsXmnHyEqVl1ahzOh5qnzjDZVem5Eb4d0dXjXa0F_Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Dhurjati",
+   "category": "sans-serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-07",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/dhurjati/v4/uV6jO5e2iFMbGB0z79Cy5g.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fasthand",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "khmer"
+   ],
+   "version": "v7",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fasthand/v7/6XAagHH_KmpZL67wTvsETQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Unlock",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-06",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/unlock/v6/rXEQzK7uIAlhoyoAEiMy1w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Arya",
+   "category": "sans-serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-05-21",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/arya/v1/xEVqtU3v8QLospHKpDaYEw.ttf",
+    "700": "http://fonts.gstatic.com/s/arya/v1/N13tgOvG7VTXawiI-fJiQA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Suravaram",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/suravaram/v3/G4dPee4pel_w2HqzavW4MA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Tillana",
+   "category": "handwriting",
+   "variants": [
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/tillana/v1/zN0D-jDPsr1HzU3VRFLY5g.ttf",
+    "500": "http://fonts.gstatic.com/s/tillana/v1/gqdUngSIcY9tSla5eCZky_esZW2xOQ-xsNqO47m55DA.ttf",
+    "600": "http://fonts.gstatic.com/s/tillana/v1/fqon6-r15hy8M1cyiYfQBvesZW2xOQ-xsNqO47m55DA.ttf",
+    "700": "http://fonts.gstatic.com/s/tillana/v1/jGARMTxLrMerzTCpGBpMffesZW2xOQ-xsNqO47m55DA.ttf",
+    "800": "http://fonts.gstatic.com/s/tillana/v1/pmTtNH_Ibktj5Cyc1XrP6vesZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Fruktur",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v6",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/fruktur/v6/PnQvfEi1LssAvhJsCwH__w.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Lakki Reddy",
+   "category": "handwriting",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/lakkireddy/v3/Q5EpFa91FjW37t0FCnedaKCWcynf_cDxXwCLxiixG1c.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Hanalei Fill",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v5",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/hanaleifill/v5/5uPeWLnaDdtm4UBG26Ds6C3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Inknut Antiqua",
+   "category": "serif",
+   "variants": [
+    "300",
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800",
+    "900"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-11",
+   "files": {
+    "300": "http://fonts.gstatic.com/s/inknutantiqua/v1/CagoW52rBcslcXzHh6tVIg6hmPNSXwHGnJQCeQHKUMo.ttf",
+    "regular": "http://fonts.gstatic.com/s/inknutantiqua/v1/VlmmTfOrxr3HfcnhMueX9arFJ4O13IHVxZbM6yoslpo.ttf",
+    "500": "http://fonts.gstatic.com/s/inknutantiqua/v1/CagoW52rBcslcXzHh6tVIiYCDvi1XFzRnTV7qUFsNgk.ttf",
+    "600": "http://fonts.gstatic.com/s/inknutantiqua/v1/CagoW52rBcslcXzHh6tVIjLEgY6PI0GrY6L00mykcEQ.ttf",
+    "700": "http://fonts.gstatic.com/s/inknutantiqua/v1/CagoW52rBcslcXzHh6tVIlRhfXn9P4_QueZ7VkUHUNc.ttf",
+    "800": "http://fonts.gstatic.com/s/inknutantiqua/v1/CagoW52rBcslcXzHh6tVInARjXVu2t2krcNTHiCb1qY.ttf",
+    "900": "http://fonts.gstatic.com/s/inknutantiqua/v1/CagoW52rBcslcXzHh6tVIrTsNy1JrFNT1qKy8j7W3CU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Peddana",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v4",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/peddana/v4/zaSZuj_GhmC8AOTugOROnA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Eczar",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "500",
+    "600",
+    "700",
+    "800"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v2",
+   "lastModified": "2015-08-12",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/eczar/v2/uKZcAQ5JBBs1UbeXFRbBRg.ttf",
+    "500": "http://fonts.gstatic.com/s/eczar/v2/Ooe4KaPp2594tF8TbMfdlQ.ttf",
+    "600": "http://fonts.gstatic.com/s/eczar/v2/IjQsWW0bmgkZ6lnN72cnTQ.ttf",
+    "700": "http://fonts.gstatic.com/s/eczar/v2/ELC8RVXfBMb3VuuHtMwBOA.ttf",
+    "800": "http://fonts.gstatic.com/s/eczar/v2/9Uyt6nTZLx_Qj5_WRah-iQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Asar",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-17",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/asar/v1/mSmn3H5CcMA84CZ586X7WQ.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Rhodium Libre",
+   "category": "serif",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/rhodiumlibre/v1/Vxr7A4-xE2zsBDDI8BcseIjjx0o0jr6fNXxPgYh_a8Q.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Ravi Prakash",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "telugu",
+    "latin"
+   ],
+   "version": "v3",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/raviprakash/v3/8EzbM7Rymjk25jWeHxbO6C3USBnSvpkopQaUR-2r7iU.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Modak",
+   "category": "display",
+   "variants": [
+    "regular"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-04-03",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/modak/v1/lMsN0QIKid-pCPvL0hH4nw.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sura",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin-ext",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-17",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sura/v1/jznKrhTH5NezYxb0-Q5zzA.ttf",
+    "700": "http://fonts.gstatic.com/s/sura/v1/Z5bXQaFGmoWicN1WlcncxA.ttf"
+   }
+  },
+  {
+   "kind": "webfonts#webfont",
+   "family": "Sahitya",
+   "category": "serif",
+   "variants": [
+    "regular",
+    "700"
+   ],
+   "subsets": [
+    "devanagari",
+    "latin"
+   ],
+   "version": "v1",
+   "lastModified": "2015-06-17",
+   "files": {
+    "regular": "http://fonts.gstatic.com/s/sahitya/v1/wQWULcDbZqljdTfjOUtDvw.ttf",
+    "700": "http://fonts.gstatic.com/s/sahitya/v1/Zm5hNvMwUyN3tC4GMkH1l_esZW2xOQ-xsNqO47m55DA.ttf"
+   }
+  }
+ ]
+}
+


### PR DESCRIPTION
Provides fallback to stored data when no API key set.
API key is set via definition instead of hard coding into the framework which meant that the framework needed to be modified to use it.
Caching to disk has been removed and replaced with the transients API.

These changes should allow themes using the Google Fonts section of this library to be accepted into the official WordPress theme repository and allow it to work with a broader range of setups and use cases.

I've done very little testing with this. It's just a quick thing I hacked together to solve a problem I was working on, but AFAIK I should work just fine and I'm not aware of any problems with it.
